### PR TITLE
Added an identifier for scanners

### DIFF
--- a/TownSuite.TwainScanner/Program.cs
+++ b/TownSuite.TwainScanner/Program.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.CodeDom.Compiler;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using System.Windows.Forms;
 

--- a/TownSuite.TwainScanner/Scanner.cs
+++ b/TownSuite.TwainScanner/Scanner.cs
@@ -30,6 +30,22 @@ namespace WIAScanner
             this._deviceInfo = deviceInfo;
         }
 
+        public override String ToString()
+        {
+            return scannerDispalyName(base.ToString(), _deviceInfo.DeviceID.ToString());
+        }
+
+        public String scannerDispalyName(String name, String id)
+        {
+            String trimmedName = name.Trim(new Char[] { ' ', '*', '.', '(', ')', '{', '}', '[', ']' });
+            int reduceIndex = trimmedName.IndexOf('.');
+            String reducedName = trimmedName.Substring(0, reduceIndex);
+            String trimmedID = id.Trim(new Char[] { ' ', '*', '.', '(', ')', '{', '}', '[', ']' });
+            String abrvID = trimmedID.Substring(0, 6);
+            String newName = abrvID;
+            return reducedName + ' ' + newName;
+        }
+
         /// <summary>
         /// Scan a image with PNG Format
         /// </summary>


### PR DESCRIPTION
Added a feature to the scanner that more clearly identifies different scanners under a uniform identifier of using the first 6 characters of the scanner ID with the exclusion of some special characters. This was made to help lower confusion for clients. The Formatting for naming scheme can easily be adjusted to something else if preferred this is just what felt like a good choice to me in the moment.

EX: "WIAScanner A1B29S"
Instead of the previous
"WIAScanner.Scanner" for every scanner.