### PR TITLE
Fix error where TwainScanner cleans out folders

### DIFF
--- a/TownSuite.TwainScanner/MainFrame.cs
+++ b/TownSuite.TwainScanner/MainFrame.cs
@@ -131,27 +131,12 @@ namespace TownSuite.TwainScanner
 
         private void DeleteFiles()
         {
-
-            if (string.Equals(DirText, System.IO.Path.Combine(Environment.GetEnvironmentVariable("TMP"), "TownSuite", "TwainScanner"), 
-                StringComparison.InvariantCultureIgnoreCase))
-            {
-                // using a custom folder.   Delete everything.
-                LoopFiles("*.bmp");
-                LoopFiles("*.jpeg");
-                LoopFiles("*.tif");
-                LoopFiles("*.png");
-                LoopFiles("*.pdf");
-                LoopFiles("*.txt");
-            }
-            else
-            {
-                LoopFiles("tmpscan*.bmp");
-                LoopFiles("tmpscan*.jpeg");
-                LoopFiles("tmpscan*.tif");
-                LoopFiles("tmpscan*.png");
-                LoopFiles("tmpscan*.pdf");
-                LoopFiles("tmpscan*.txt");
-            }
+            LoopFiles("tmpscan*.bmp");
+            LoopFiles("tmpscan*.jpeg");
+            LoopFiles("tmpscan*.tif");
+            LoopFiles("tmpscan*.png");
+            LoopFiles("tmpscan*.pdf");
+            LoopFiles("tmpscan*.txt");
         }
 
         private void LoopFiles(string fileext)

--- a/TownSuite.TwainScanner/MainFrame.cs
+++ b/TownSuite.TwainScanner/MainFrame.cs
@@ -131,12 +131,12 @@ namespace TownSuite.TwainScanner
 
         private void DeleteFiles()
         {
-            LoopFiles("tmpscan*.bmp");
-            LoopFiles("tmpscan*.jpeg");
-            LoopFiles("tmpscan*.tif");
-            LoopFiles("tmpscan*.png");
-            LoopFiles("tmpscan*.pdf");
-            LoopFiles("tmpscan*.txt");
+            LoopFiles("tmpScan.bmp");
+            LoopFiles("tmpScan.jpeg");
+            LoopFiles("tmpScan.tif");
+            LoopFiles("tmpScan.png");
+            LoopFiles("tmpScan.pdf");
+            LoopFiles("tmpScan.txt");
         }
 
         private void LoopFiles(string fileext)


### PR DESCRIPTION
This fixes an issue discovered in Financial where the scanner was taking out scanned files that are within the "OCR" folder which is considered as a "custom folder" to delete everything out of. This Will probably require a follow up fix to allow for proper cleaning of temp items from folders.