### PR TITLE
Refactor scanner backend and update documentation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,6 +5,11 @@ You can use this library in your programs written in any programming languages c
 
 Fork of https://sarafftwain.codeplex.com/
 
+
+# Scanner setup
+
+* Install your printers twain driver with its official driver pack
+
 # Usage
 
 ```powershell

--- a/TownSuite.TwainScanner.sln
+++ b/TownSuite.TwainScanner.sln
@@ -7,18 +7,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TwainScanner", "TownSuite.T
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
-		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{658F9851-4D1C-4D57-904E-F9D7DA7F24FC}.Debug|x64.ActiveCfg = Debug|x64
-		{658F9851-4D1C-4D57-904E-F9D7DA7F24FC}.Debug|x64.Build.0 = Debug|x64
 		{658F9851-4D1C-4D57-904E-F9D7DA7F24FC}.Debug|x86.ActiveCfg = Debug|x86
 		{658F9851-4D1C-4D57-904E-F9D7DA7F24FC}.Debug|x86.Build.0 = Debug|x86
-		{658F9851-4D1C-4D57-904E-F9D7DA7F24FC}.Release|x64.ActiveCfg = Release|x64
-		{658F9851-4D1C-4D57-904E-F9D7DA7F24FC}.Release|x64.Build.0 = Release|x64
 		{658F9851-4D1C-4D57-904E-F9D7DA7F24FC}.Release|x86.ActiveCfg = Release|x86
 		{658F9851-4D1C-4D57-904E-F9D7DA7F24FC}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection

--- a/TownSuite.TwainScanner/Backends/IBackend.cs
+++ b/TownSuite.TwainScanner/Backends/IBackend.cs
@@ -1,0 +1,465 @@
+﻿using System.Collections.Generic;
+using System.Drawing.Imaging;
+using System.Drawing;
+using System.IO;
+using System;
+using System.Linq;
+using System.Text.RegularExpressions;
+using iTextSharp.text.pdf;
+using iTextSharp.text;
+using NAPS2.Images;
+using PdfSharpCore.Drawing;
+using System.Windows.Forms;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+
+namespace TownSuite.TwainScanner.Backends
+{
+    internal class IBackend : IDisposable
+    {
+        protected string imageFormat;
+        protected readonly string DirText;
+        protected string FileExtention;
+        protected string imageExtension;
+        readonly Ocr ocr;
+        public MainFrame ParentForm
+        {
+            get; set;
+        }
+
+        public IBackend(string dirText, Ocr ocr)
+        {
+            this.DirText = dirText;
+            this.ocr = ocr;
+        }
+
+        public virtual Task ConfigureSettings()
+        {
+            if (!System.IO.Directory.Exists(DirText))
+            {
+                System.IO.Directory.CreateDirectory(DirText);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public virtual void ChangeSelectedScanner(object value)
+        {
+
+        }
+
+        public virtual void HandleErrors()
+        {
+
+        }
+
+        public virtual Task Scan(string imageFormat)
+        {
+            this.imageFormat = imageFormat.ToLower().Trim();
+            switch (imageFormat)
+            {
+                case "tiff":
+                    FileExtention = ".tif";
+                    imageExtension = ".tif";
+                    break;
+                case "png":
+                    // PDFs will internally be png images
+                    FileExtention = ".png";
+                    imageExtension = ".png";
+                    break;
+                case "pdf":
+                    FileExtention = ".pdf";
+                    imageExtension = ".jpeg";
+                    break;
+                case "jpeg":
+                    FileExtention = ".jpeg";
+                    imageExtension = ".jpeg";
+                    break;
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public virtual void Save()
+        {
+            switch (imageFormat)
+            {
+                case "tiff":
+                    //Save tiff
+                    Save_TIFF();
+                    break;
+                case "png":
+                    SavePNG();
+                    break;
+                case "jpeg":
+                    SaveJPEG();
+                    break;
+                case "pdf":
+                    //Save pdf
+                    SavePDF();
+                    break;
+            }
+
+            Console.WriteLine();
+            Console.WriteLine(" " + FileExtention + " ");
+            Console.WriteLine();
+            Console.WriteLine("SAVED");
+            Console.Out.Flush();
+        }
+
+        protected string PadNumbers(string input)
+        {
+            string smallName = System.IO.Path.GetFileNameWithoutExtension(input);
+            // Default ordering for a string is standard alpha numeric dictionary ordering.
+            // when individual files like tmpScan1_0.bmp , tmpScan2_1.bmp .....tmpScan10_9.bmp, tmpScan11_10
+            //Then tmpScan1_0.bmp will be first and order the files and tmpScan10_9.bmp, tmpScan11_10 after
+            return Regex.Replace(smallName, "[0-9]+", match => match.Value.PadLeft(10, '0'));
+        }
+
+        private void Save_TIFF()
+        {
+            string[] sa = null;
+            sa = Directory.GetFiles(DirText, "tmpscan*.tif");
+
+            List<string> UnSortList = new List<string>(sa);
+            List<string> SortedList = UnSortList.OrderBy(p => PadNumbers(p)).ToList();
+            sa = SortedList.ToArray();
+
+            //get the codec for tiff files
+            ImageCodecInfo info = ImageCodecInfo.GetImageEncoders().Where(p => p.MimeType == "image/tiff").FirstOrDefault();
+
+            //use the save encoder
+            var enc = System.Drawing.Imaging.Encoder.SaveFlag;
+            EncoderParameters ep = new EncoderParameters(1);
+
+            ep.Param[0] = new EncoderParameter(enc, Convert.ToInt64(EncoderValue.MultiFrame));
+
+            Bitmap pages = null;
+            int frame = 0;
+
+            foreach (string s in sa)
+            {
+                if (frame == 0)
+                {
+                    pages = (Bitmap)System.Drawing.Image.FromFile(s);
+
+                    //save the first frame
+                    pages.Save(Path.Combine(DirText, "tmpScan.tif"), info, ep);
+                }
+                else
+                {
+                    //save the intermediate frames
+                    ep.Param[0] = new EncoderParameter(enc, Convert.ToInt64(EncoderValue.FrameDimensionPage));
+                    using (Bitmap bm = (Bitmap)System.Drawing.Image.FromFile(s))
+                    {
+                        pages.SaveAdd(bm, ep);
+                    }
+                }
+                if (frame == sa.Length - 1)
+                {
+                    //flush and close.
+                    ep.Param[0] = new EncoderParameter(enc, Convert.ToInt64(EncoderValue.Flush));
+                    pages.SaveAdd(ep);
+
+                }
+                frame += 1;
+
+            }
+        }
+
+        private string SavePNG()
+        {
+            string[] inputFiles = Directory.GetFiles(DirText, "tmpscan*.png");
+
+            // TODO: You may want to add input checking here.
+            System.Drawing.Image[] images = new System.Drawing.Image[inputFiles.Length];
+            System.Drawing.Image image;
+            int height = 0, width = 0;
+
+            try
+            {
+                for (int i = 0; i < inputFiles.Length; ++i)
+                {
+                    images[i] = image = System.Drawing.Image.FromFile(inputFiles[i]);
+                    height = Math.Max(height, image.Height);
+                    width += image.Width;
+                }
+
+                image = new Bitmap(width, height, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
+
+                using (Graphics g = Graphics.FromImage(image))
+                {
+                    // Clear the background to transparent.
+                    g.Clear(System.Drawing.Color.Transparent);
+
+                    width = 0;
+
+                    for (int i = 0; i < images.Length; ++i)
+                    {
+                        double scale = (double)height / images[i].Height;
+                        int scaledWidth = (int)(images[i].Width * scale);
+                        // Draw the image scaled to match the maxHeight
+                        g.DrawImage(images[i],
+                                    new System.Drawing.Rectangle(width, 0, scaledWidth, height),
+                                    new System.Drawing.Rectangle(0, 0, images[i].Width, images[i].Height),
+                                    GraphicsUnit.Pixel);
+                        width += scaledWidth;
+
+                        // free memory immediately to avoid out of memory exception as 'image' grows.
+                        if (images[i] != null)
+                            images[i].Dispose();
+                    }
+                }
+
+                // You don't need to save this in order to use the in-memory object.
+                // img3.Save(finalImage, System.Drawing.Imaging.ImageFormat.Jpeg);
+
+                image.Save(Path.Combine(DirText, "tmpScan.png"));
+                //imageLocation.Image = image;
+            }
+            finally
+            {
+                // in case of exception dispose everything properly
+                for (int i = 0; i < inputFiles.Length; ++i)
+                    images[i]?.Dispose();
+            }
+
+            return "";
+        }
+
+        private void SavePDF()
+        {
+            var predefinedSizes = new[]
+        {
+            new { Size = iTextSharp.text.PageSize.A4, Width = 21f, Height = 29.7f },
+            new { Size = iTextSharp.text.PageSize.A3, Width = 29.7f, Height = 42f },
+            new { Size = new iTextSharp.text.Rectangle(21.59f * 28.35f, 27.94f * 28.35f), Width = 21.59f, Height = 27.94f },  // Letter (8.5" x 11")
+            new { Size = new iTextSharp.text.Rectangle(21.59f * 28.35f, 35.56f * 28.35f), Width = 21.59f, Height = 35.56f },  // Legal (8.5" x 14")
+            new { Size = new iTextSharp.text.Rectangle(15.24f * 28.35f, 6.99f * 28.35f), Width = 15.24f, Height = 6.99f },  // Cheque: 6" x 2.75"
+            new { Size = new  iTextSharp.text.Rectangle(8f * 28.35f, 30f * 28.35f), Width = 8f, Height = 30f }  // Receipt: 80mm x 300mm (approx)
+        };
+
+            string[] sa = Directory.GetFiles(DirText, "tmpscan*.jpeg");
+
+            List<string> UnSortList = new List<string>(sa);
+            List<string> SortedList = UnSortList.OrderBy(p => PadNumbers(p)).ToList();
+            sa = SortedList.ToArray();
+            string outputPdfPath = Path.Combine(DirText, "tmpscan.pdf");
+
+            using (FileStream fs = new FileStream(outputPdfPath, FileMode.Create, FileAccess.Write, FileShare.None))
+            using (Document doc = new Document(iTextSharp.text.PageSize.A4)) // Default to A4, will resize per page
+            using (PdfWriter writer = PdfWriter.GetInstance(doc, fs))
+            {
+                doc.Open();
+
+                foreach (string imagePath in sa)
+                {
+                    byte[] imageBytes = File.ReadAllBytes(imagePath);
+                    using (MemoryStream ms = new MemoryStream(imageBytes))
+                    using (System.Drawing.Image sysImage = System.Drawing.Image.FromStream(ms))
+                    {
+                        float dpiX = sysImage.HorizontalResolution;
+                        float dpiY = sysImage.VerticalResolution;
+                        float widthInches = sysImage.Width / dpiX;
+                        float heightInches = sysImage.Height / dpiY;
+                        float imageWidthCm = widthInches * 2.54f;
+                        float imageHeightCm = heightInches * 2.54f;
+
+                        bool isLandscape = imageWidthCm > imageHeightCm;
+                        float actualWidth = imageWidthCm;
+                        float actualHeight = imageHeightCm;
+                        if (isLandscape)
+                        {
+                            actualWidth = imageHeightCm;
+                            actualHeight = imageWidthCm;
+                        }
+
+                        // Choose the best predefined paper size
+                        float bestDiff = float.MaxValue;
+                        var bestPaper = predefinedSizes[0];
+
+                        foreach (var paper in predefinedSizes)
+                        {
+                            float paperWidth = paper.Width;
+                            float paperHeight = paper.Height;
+
+                            if (isLandscape && paperWidth < paperHeight)
+                            {
+                                float temp = paperWidth;
+                                paperWidth = paperHeight;
+                                paperHeight = temp;
+                            }
+
+                            float diff = Math.Abs(actualWidth - paperWidth) + Math.Abs(actualHeight - paperHeight);
+                            if (diff < bestDiff)
+                            {
+                                bestDiff = diff;
+                                bestPaper = paper;
+                            }
+                        }
+
+                        // Create a new page for each image
+                        doc.SetPageSize(bestPaper.Size);
+                        doc.NewPage();
+
+                        // Add image to the PDF
+                        iTextSharp.text.Image pdfImage = iTextSharp.text.Image.GetInstance(imageBytes);
+                        pdfImage.ScaleToFit(bestPaper.Size.Width, bestPaper.Size.Height);
+                        pdfImage.SetAbsolutePosition(0, 0);
+                        doc.Add(pdfImage);
+                    }
+                }
+
+                doc.Close();
+            }
+
+        }
+
+        private string SaveJPEG()
+        {
+            string[] inputFiles = Directory.GetFiles(DirText, "tmpscan*.jpeg");
+
+            // TODO: You may want to add input checking here.
+            System.Drawing.Image[] images = new System.Drawing.Image[inputFiles.Length];
+            System.Drawing.Image image;
+            int height = 0, width = 0;
+
+            try
+            {
+                for (int i = 0; i < inputFiles.Length; ++i)
+                {
+                    images[i] = image = System.Drawing.Image.FromFile(inputFiles[i]);
+                    height = Math.Max(height, image.Height);
+                    width += image.Width;
+                }
+
+                image = new Bitmap(width, height, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
+
+                using (Graphics g = Graphics.FromImage(image))
+                {
+                    // Clear the background to transparent.
+                    g.Clear(System.Drawing.Color.Transparent);
+
+                    width = 0;
+
+                    for (int i = 0; i < images.Length; ++i)
+                    {
+                        double scale = (double)height / images[i].Height;
+                        int scaledWidth = (int)(images[i].Width * scale);
+                        // Draw the image scaled to match the maxHeight
+                        g.DrawImage(images[i],
+                                    new System.Drawing.Rectangle(width, 0, scaledWidth, height),
+                                    new System.Drawing.Rectangle(0, 0, images[i].Width, images[i].Height),
+                                    GraphicsUnit.Pixel);
+                        width += scaledWidth;
+
+                        // free memory immediately to avoid out of memory exception as 'image' grows.
+                        if (images[i] != null)
+                            images[i].Dispose();
+                    }
+                }
+                image.Save(Path.Combine(DirText, "tmpScan.jpeg"));
+                //imageLocation.Image = image;
+            }
+            finally
+            {
+                // in case of exception dispose everything properly
+                for (int i = 0; i < inputFiles.Length; ++i)
+                    if (images[i] != null)
+                        images[i].Dispose();
+            }
+
+            return "";
+        }
+
+        public void DeleteFiles()
+        {
+
+            if (string.Equals(DirText, System.IO.Path.Combine(Environment.GetEnvironmentVariable("TMP"), "TownSuite", "TwainScanner"),
+                StringComparison.InvariantCultureIgnoreCase))
+            {
+                // using a custom folder.   Delete everything.
+                LoopFiles("*.bmp");
+                LoopFiles("*.jpeg");
+                LoopFiles("*.tif");
+                LoopFiles("*.png");
+                LoopFiles("*.pdf");
+                LoopFiles("*.txt");
+            }
+            else
+            {
+                LoopFiles("tmpscan*.bmp");
+                LoopFiles("tmpscan*.jpeg");
+                LoopFiles("tmpscan*.tif");
+                LoopFiles("tmpscan*.png");
+                LoopFiles("tmpscan*.pdf");
+                LoopFiles("tmpscan*.txt");
+            }
+        }
+
+        private void LoopFiles(string fileext)
+        {
+            //New Stuff
+            //---------------------------
+            string[] sa = Directory.GetFiles(DirText, fileext);
+
+            foreach (string s_loopVariable in sa)
+            {
+                string s = s_loopVariable;
+                File.Delete(s);
+            }
+        }
+
+        protected void RunOcr(PictureBox newpic, string origPath, bool ocrCheckboxChecked)
+        {
+            if (ocr.Enabled && ocrCheckboxChecked)
+            {
+                ocr.GetText(origPath, newpic, ParentForm.GetProgressBar(), ParentForm.GetStatusLabel());
+            }
+        }
+
+        protected bool OcrEnabled() { return ocr.Enabled; }
+        public virtual void EnableOcr(bool enable)
+        {
+            ocr.Enabled = enable;
+        }
+
+        protected void Newpic_MouseLeave(object sender, EventArgs e)
+        {
+            if (sender is PictureBox == false)
+            {
+                return;
+            }
+            var pb = sender as PictureBox;
+            pb.BorderStyle = BorderStyle.None;
+        }
+
+        protected void Newpic_MouseEnter(object sender, EventArgs e)
+        {
+            if (sender is PictureBox == false)
+            {
+                return;
+            }
+            var pb = sender as PictureBox;
+            pb.BorderStyle = BorderStyle.FixedSingle;
+        }
+
+        protected void Newpic_DoubleClick(object sender, EventArgs e)
+        {
+            if (sender is PictureBox == false)
+            {
+                return;
+            }
+            var pb = sender as PictureBox;
+            if (System.IO.File.Exists(pb.Tag?.ToString() ?? ""))
+            {
+                System.Diagnostics.Process.Start(pb.Tag.ToString());
+            }
+        }
+
+        public virtual void Dispose()
+        {
+            
+        }
+    }
+}

--- a/TownSuite.TwainScanner/Backends/Naps2TwainBackend.cs
+++ b/TownSuite.TwainScanner/Backends/Naps2TwainBackend.cs
@@ -17,7 +17,7 @@ using System.IO;
 
 namespace TownSuite.TwainScanner.Backends
 {
-    class Naps2Backend : IBackend
+    class Naps2Backend : ScannerBackends
     {
         ScanningContext scanningContext;
         ScanController controller;

--- a/TownSuite.TwainScanner/Backends/Naps2TwainBackend.cs
+++ b/TownSuite.TwainScanner/Backends/Naps2TwainBackend.cs
@@ -34,6 +34,15 @@ namespace TownSuite.TwainScanner.Backends
             scanningContext = new ScanningContext(new GdiImageContext());
             scanningContext.SetUpWin32Worker();
 
+
+        //        public WorkerFactory(string nativeWorkerExePath, string? winX86WorkerExePath = null, Dictionary<string, string>? environmentVariables = null)
+        //{
+        //    NativeWorkerExePath = nativeWorkerExePath;
+        //    WinX86WorkerExePath = winX86WorkerExePath;
+        //    _environmentVariables = environmentVariables ?? new Dictionary<string, string>();
+        //}
+        //PlatformCompat.System.NativeWorkerAlias
+
             controller = new ScanController(scanningContext);
 
             var scanOptions = new ScanOptions()
@@ -42,20 +51,25 @@ namespace TownSuite.TwainScanner.Backends
                 PageSize = PageSize.Letter,
                 Dpi = 300,
                 UseNativeUI = true,
-                Driver = Driver.Twain,
-
+                Driver = Driver.Twain
             };
             var devices = (await controller.GetDeviceList(scanOptions));
 
             var sourceTwainListBox = ParentForm.GetTwainSourceList();
             sourceTwainListBox.Items.Clear();
 
-            foreach (var device in devices)
-            {
-                var options = new ScanOptions { Device = device };
+            sourceTwainListBox.DataSource = devices;
+            sourceTwainListBox.DisplayMember = "Name";
 
-                sourceTwainListBox.Items.Add(options);
-            }
+            //foreach (var device in devices)
+            //{
+            //    var options = new ScanOptions { Device = device };
+
+            //    sourceTwainListBox.Items.Add(options);
+            //    // set the display name
+                
+            //    sourceTwainListBox.Items[sourceTwainListBox.Items.Count - 1] = device.Name;
+            //}
             sourceTwainListBox.SelectedIndex = 0;
         }
 
@@ -64,22 +78,8 @@ namespace TownSuite.TwainScanner.Backends
         {
             await base.Scan(imageFormat);
 
-            // Scanning with TWAIN on Windows must happen from a 32-bit process. You can do this by building your exe as
-            // 32-bit, but the better solution is to install the NAPS2.Sdk.Worker.Win32 Nuget package, which includes a
-            // pre-compiled 32-bit NAPS2.Worker.exe. Then you only need to call ScanningContext.SetUpWin32Worker and you
-            // should be able to scan with TWAIN.
-            //
-            // If you want to use a worker process but don't want to use a pre-compiled exe (or want to set up your own
-            // logging etc), you can also build your own worker exe with the same name (and call WorkerServer.Run in its
-            // Main method).
-
-
-            // Set up the worker; this includes starting a worker process in the background so it will be ready to respond
-            // when we need it
-
-
-            // As we're not using the default (WIA) driver, we need to specify it when listing devices or scanning
-            ScanDevice device = (await controller.GetDeviceList(Driver.Twain)).First();
+            var sourceTwainListBox = ParentForm.GetTwainSourceList();
+            var device = sourceTwainListBox.SelectedItem as ScanDevice;
             var options = new ScanOptions { Device = device };
 
             await foreach (var image in controller.Scan(options))
@@ -138,39 +138,6 @@ namespace TownSuite.TwainScanner.Backends
         {
             base.Dispose();
             this.scanningContext?.Dispose();
-        }
-
-        public async Task Init()
-        {
-            //// Set up
-            //using (var scanningContext = new ScanningContext(new GdiImageContext()))
-            //{
-            //    var controller = new ScanController(scanningContext);
-
-            //    // Query for available scanning devices
-            //    var devices = await controller.GetDeviceList();
-
-            //    // Set scanning options
-            //    var options = new ScanOptions
-            //    {
-            //        Device = devices.First(),
-            //        PaperSource = PaperSource.Feeder,
-            //        PageSize = PageSize.A4,
-            //        Dpi = 300
-            //    };
-
-            //    // Scan and save images
-            //    int i = 1;
-            //    await foreach (var image in controller.Scan(options))
-            //    {
-            //        image.Save($"page{i++}.jpg");
-            //    }
-
-            //    // Scan and save PDF
-            //    var images = await controller.Scan(options).ToListAsync();
-            //    var pdfExporter = new PdfExporter(scanningContext);
-            //    await pdfExporter.Export("doc.pdf", images);
-            //}
         }
     }
 }

--- a/TownSuite.TwainScanner/Backends/Naps2TwainBackend.cs
+++ b/TownSuite.TwainScanner/Backends/Naps2TwainBackend.cs
@@ -1,0 +1,178 @@
+﻿#if NET8_0_OR_GREATER
+using NAPS2.Images;
+using NAPS2.Images.Gdi;
+using NAPS2.Pdf;
+using NAPS2.Scan;
+using System;
+using System.Collections.Generic;
+using System.Drawing.Imaging;
+using System.Drawing;
+using System.Linq;
+using System.Security.RightsManagement;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using System.IO;
+
+
+namespace TownSuite.TwainScanner.Backends
+{
+    class Naps2Backend : IBackend
+    {
+        ScanningContext scanningContext;
+        ScanController controller;
+        public Naps2Backend(string dirText, Ocr ocr) : base(dirText, ocr)
+        {
+            // Constructor logic here
+        }
+
+        public override async Task ConfigureSettings()
+        {
+            await base.ConfigureSettings();
+            // Initialize NAPS2 scanning context and other settings here
+
+            scanningContext = new ScanningContext(new GdiImageContext());
+            scanningContext.SetUpWin32Worker();
+
+            controller = new ScanController(scanningContext);
+
+            var scanOptions = new ScanOptions()
+            {
+                PaperSource = PaperSource.Auto,
+                PageSize = PageSize.Letter,
+                Dpi = 300,
+                UseNativeUI = true,
+                Driver = Driver.Twain,
+
+            };
+            var devices = (await controller.GetDeviceList(scanOptions));
+
+            var sourceTwainListBox = ParentForm.GetTwainSourceList();
+            sourceTwainListBox.Items.Clear();
+
+            foreach (var device in devices)
+            {
+                var options = new ScanOptions { Device = device };
+
+                sourceTwainListBox.Items.Add(options);
+            }
+            sourceTwainListBox.SelectedIndex = 0;
+        }
+
+        int picnumber = 0;
+        public override async Task Scan(string imageFormat)
+        {
+            await base.Scan(imageFormat);
+
+            // Scanning with TWAIN on Windows must happen from a 32-bit process. You can do this by building your exe as
+            // 32-bit, but the better solution is to install the NAPS2.Sdk.Worker.Win32 Nuget package, which includes a
+            // pre-compiled 32-bit NAPS2.Worker.exe. Then you only need to call ScanningContext.SetUpWin32Worker and you
+            // should be able to scan with TWAIN.
+            //
+            // If you want to use a worker process but don't want to use a pre-compiled exe (or want to set up your own
+            // logging etc), you can also build your own worker exe with the same name (and call WorkerServer.Run in its
+            // Main method).
+
+
+            // Set up the worker; this includes starting a worker process in the background so it will be ready to respond
+            // when we need it
+
+
+            // As we're not using the default (WIA) driver, we need to specify it when listing devices or scanning
+            ScanDevice device = (await controller.GetDeviceList(Driver.Twain)).First();
+            var options = new ScanOptions { Device = device };
+
+            await foreach (var image in controller.Scan(options))
+            {
+                picnumber += 1;
+                var newpic = new PictureBox();
+                System.Drawing.Image resizedImg;
+                string origPath = Path.Combine(DirText, "tmpScan" + picnumber.ToString() + "_" + picnumber.ToString() + Guid.NewGuid().ToString() + imageExtension);
+                newpic.Tag = origPath;
+
+                using Bitmap img = image.RenderToBitmap();
+
+
+                switch (imageFormat)
+                {
+                    case "tiff":
+                        img.Save(origPath, ImageFormat.Tiff);
+                        break;
+                    case "png":
+                        img.Save(origPath, ImageFormat.Png);
+                        break;
+                    case "pdf":
+                    case "jpeg":
+                    default:
+                        // pdf is just an import of a file.  Use jpg.
+                        img.Save(origPath, ImageFormat.Jpeg);
+                        break;
+                }
+
+                resizedImg = new Bitmap(img, new Size(180, 180));
+
+
+                newpic.Image = resizedImg;
+                newpic.Size = new Size(newpic.Image.Width, newpic.Image.Height);
+                newpic.Refresh();
+                newpic.DoubleClick += Newpic_DoubleClick;
+                newpic.MouseEnter += Newpic_MouseEnter;
+                newpic.MouseLeave += Newpic_MouseLeave;
+                var flowLayoutPanel1 = ParentForm.GetFlowLayoutPanel();
+                newpic.Text = "ScanPass" + picnumber.ToString() + "_Pic" + picnumber.ToString();
+                flowLayoutPanel1.Controls.Add(newpic);
+                // newpic.doTmpSave(DirText + "\\tmpScan" + picnumber.ToString() + "_" + i.ToString() + ".bmp");
+
+                RunOcr(newpic, origPath, OcrEnabled());
+
+                Console.WriteLine("Scanned a page!");
+                picnumber += 1;
+            }
+        }
+        public override void Save()
+        {
+            base.Save();
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
+            this.scanningContext?.Dispose();
+        }
+
+        public async Task Init()
+        {
+            //// Set up
+            //using (var scanningContext = new ScanningContext(new GdiImageContext()))
+            //{
+            //    var controller = new ScanController(scanningContext);
+
+            //    // Query for available scanning devices
+            //    var devices = await controller.GetDeviceList();
+
+            //    // Set scanning options
+            //    var options = new ScanOptions
+            //    {
+            //        Device = devices.First(),
+            //        PaperSource = PaperSource.Feeder,
+            //        PageSize = PageSize.A4,
+            //        Dpi = 300
+            //    };
+
+            //    // Scan and save images
+            //    int i = 1;
+            //    await foreach (var image in controller.Scan(options))
+            //    {
+            //        image.Save($"page{i++}.jpg");
+            //    }
+
+            //    // Scan and save PDF
+            //    var images = await controller.Scan(options).ToListAsync();
+            //    var pdfExporter = new PdfExporter(scanningContext);
+            //    await pdfExporter.Export("doc.pdf", images);
+            //}
+        }
+    }
+}
+
+#endif

--- a/TownSuite.TwainScanner/Backends/OriginalTwainBackend.cs
+++ b/TownSuite.TwainScanner/Backends/OriginalTwainBackend.cs
@@ -1,0 +1,153 @@
+﻿using NAPS2.Images;
+using System;
+using System.Collections.Generic;
+using System.Drawing.Imaging;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using System.IO;
+
+namespace TownSuite.TwainScanner.Backends
+{
+    class OriginalTwainBackend : IBackend
+    {
+        private Twain32 _twain;
+
+        public OriginalTwainBackend(string dirText, Ocr ocr) : base(dirText, ocr)
+        {
+        }
+
+        public override async Task ConfigureSettings()
+        {
+            await base.ConfigureSettings();
+
+            _twain = new Twain32();
+            this._twain.OpenDSM();
+            this._twain.AcquireCompleted += new System.EventHandler(this._twain_AcquireCompleted);
+
+            LoadTwainDrivers();
+        }
+
+        public override void ChangeSelectedScanner(object value)
+        {
+            var sourceTwainListBox = ParentForm.GetTwainSourceList();
+            if (sourceTwainListBox.SelectedIndex >= 0)
+            {
+                this._twain.SourceIndex = Convert.ToInt32(value);
+            }
+        }
+
+        #region Load Twian Drivers
+
+        public Twain32 Twain
+        {
+            get;
+            set;
+        }
+
+        private void LoadTwainDrivers()
+        {
+            try
+            {
+                var sourceTwainListBox = ParentForm.GetTwainSourceList();
+                sourceTwainListBox.Items.Clear();
+                //this._twain.CloseDataSource();
+                //this._twain.SelectSource();
+                Twain = this._twain;
+
+                //if (sourceTwainListBox.Items.Count == 0) { 
+                if (this.Twain != null && this.Twain.SourcesCount > 0)
+                {
+                    for (int i = 0; i < this.Twain.SourcesCount; i++)
+                    {
+                        bool twn2 = this.Twain.GetIsSourceTwain2Compatible(i);
+                        sourceTwainListBox.Items.Add(this.Twain.GetSourceProductName(i));
+                    }
+                    sourceTwainListBox.SelectedIndex = this.Twain.SourceIndex;
+                }
+
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.Message, ex.GetType().Name, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+        #endregion
+
+        public override Task Scan(string imageFormat)
+        {
+            base.Scan(imageFormat);
+
+            this._twain.Acquire();
+            return Task.CompletedTask;
+        }
+
+        int picnumber = 0;
+        private void _twain_AcquireCompleted(object sender, EventArgs e)
+        {
+            try
+            {
+                if (this._twain.ImageCount > 0)
+                {
+                    for (int i = 0; i <= this._twain.ImageCount - 1; i += 1)
+                    {
+                        picnumber += 1;
+                        var newpic = new PictureBox();
+                        System.Drawing.Image resizedImg;
+                        string origPath = Path.Combine(DirText, "tmpScan" + picnumber.ToString() + "_" + i.ToString() + Guid.NewGuid().ToString() + imageExtension);
+                        newpic.Tag = origPath;
+                        using (var img = this._twain.GetImage(i))
+                        {
+                            switch (imageFormat)
+                            {
+                                case "tiff":
+                                    img.Save(origPath, ImageFormat.Tiff);
+                                    break;
+                                case "png":
+                                    img.Save(origPath, ImageFormat.Png);
+                                    break;
+                                case "pdf":
+                                case "jpeg":
+                                default:
+                                    // pdf is just an import of a file.  Use jpg.
+                                    img.Save(origPath, ImageFormat.Jpeg);
+                                    break;
+                            }
+
+                            resizedImg = new Bitmap(img, new Size(180, 180));
+                        }
+
+                        newpic.Image = resizedImg;
+                        newpic.Size = new Size(newpic.Image.Width, newpic.Image.Height);
+                        newpic.Refresh();
+                        newpic.DoubleClick += Newpic_DoubleClick;
+                        newpic.MouseEnter += Newpic_MouseEnter;
+                        newpic.MouseLeave += Newpic_MouseLeave;
+                        var flowLayoutPanel1 = ParentForm.GetFlowLayoutPanel();
+                        newpic.Text = "ScanPass" + picnumber.ToString() + "_Pic" + picnumber.ToString();
+                        flowLayoutPanel1.Controls.Add(newpic);
+                        // newpic.doTmpSave(DirText + "\\tmpScan" + picnumber.ToString() + "_" + i.ToString() + ".bmp");
+
+                        RunOcr(newpic, origPath, OcrEnabled());
+                    }
+
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.Message, I18N.GetString("TownSuiteScan"), MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
+
+            this._twain?.CloseDataSource();
+            this._twain?.CloseDSM();
+            this._twain.Dispose();
+        }
+    }
+}

--- a/TownSuite.TwainScanner/Backends/OriginalTwainBackend.cs
+++ b/TownSuite.TwainScanner/Backends/OriginalTwainBackend.cs
@@ -11,7 +11,7 @@ using System.IO;
 
 namespace TownSuite.TwainScanner.Backends
 {
-    class OriginalTwainBackend : IBackend
+    class OriginalTwainBackend : ScannerBackends
     {
         private Twain32 _twain;
 

--- a/TownSuite.TwainScanner/Backends/OriginalWiaBackend.cs
+++ b/TownSuite.TwainScanner/Backends/OriginalWiaBackend.cs
@@ -1,0 +1,393 @@
+﻿#if INCLUDE_WIA
+using NAPS2.Images;
+using System;
+using System.Collections.Generic;
+using System.Drawing.Imaging;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using System.IO;
+using WIA;
+using System.Threading;
+using System.Collections;
+using System.Data;
+
+namespace TownSuite.TwainScanner.Backends
+{
+    class OriginalWiaBackend : IBackend
+    {
+
+        private DeviceManager deviceManager;
+        bool removeWia = false;
+
+
+        public OriginalWiaBackend(string dirText, Ocr ocr) : base(dirText, ocr)
+        {
+        }
+
+        public override async Task ConfigureSettings()
+        {
+            await base.ConfigureSettings();
+
+            LoadWIADrivers();
+            GetColors();
+        }
+
+        public override void ChangeSelectedScanner(object value)
+        {
+            var sourceTwainListBox = value as ListBox;
+            LoadScanPropertyValues(sourceTwainListBox);
+        }
+
+        public override Task Scan(string imageFormat)
+        {
+            base.Scan(imageFormat);
+
+            StartWIAScanning(base.imageFormat);
+            return Task.CompletedTask;
+        }
+
+        public void GetColors()
+        {
+            DataTable dtColors = new DataTable();
+            DataColumn newColType = new DataColumn("Type", typeof(String));
+            DataColumn newColCode = new DataColumn("Code", typeof(int));
+            dtColors.Columns.Add(newColType);
+            dtColors.Columns.Add(newColCode);
+            dtColors.Rows.Add(new object[] { "Color", 1 });
+            dtColors.Rows.Add(new object[] { "Grayscale", 2 });
+            dtColors.Rows.Add(new object[] { "Black & White", 4 });
+
+            var cmbColor = ParentForm.GetWiaColor();
+            cmbColor.DisplayMember = "Type";
+            cmbColor.ValueMember = "Code";
+            cmbColor.DataSource = dtColors;
+        }
+
+        private void LoadWIADrivers()
+        {
+            // Clear the ListBox.
+            var sourceList = ParentForm.GetWiaSourceList();
+            sourceList.Items.Clear();
+
+            // Create a DeviceManager instance
+            deviceManager = new DeviceManager();
+
+
+            // Loop through the list of devices and add the name to the listbox
+            for (int i = 1; i <= deviceManager.DeviceInfos.Count; i++)
+            {
+                // Add the device only if it's a scanner
+                if (deviceManager.DeviceInfos[i].Type != WiaDeviceType.ScannerDeviceType)
+                {
+                    continue;
+                }
+
+                // Add the Scanner device to the listbox (the entire DeviceInfos object)
+                // Important: we store an object of type scanner (which ToString method returns the name of the scanner)
+                sourceList.Items.Add(
+                    new WIAScanner.Scanner(deviceManager.DeviceInfos[i])
+                );
+            }
+            // sourceList.SelectedIndex = 
+
+        }
+
+        private WIA.Device DoSomething(DeviceInfo deviceproInfo)
+        {
+            try
+            {
+                WIA.Device device = deviceproInfo.Connect();
+                return device;
+            }
+            catch (ThreadAbortException)
+            {
+                // cleanup code, if needed...
+                return null;
+            }
+        }
+
+        public void LoadScanPropertyValues(ListBox sourceListBox) // async Task
+        {
+            var devicescanner = sourceListBox.SelectedItem as WIAScanner.Scanner;
+            if (devicescanner == null)
+            {
+                return;
+            }
+
+            WIA.Device device = null;
+
+            DeviceInfo deviceproInfo;
+            deviceproInfo = deviceManager.DeviceInfos[sourceListBox.SelectedIndex + 1];
+
+            Thread t = new Thread(() => { device = DoSomething(deviceproInfo); });
+            t.Start();
+            if (!t.Join(TimeSpan.FromSeconds(5)))
+            {
+                t.Abort();
+                throw new Exception("More than 5 secs.");
+            }
+
+
+            // device = ConnectWIA();
+
+            //--------------------------------------------------
+            var deviceitem = device.Items[1];
+
+            IProperties properties;
+            properties = deviceitem.Properties;
+
+            foreach (Property item in deviceitem.Properties)
+            {
+                switch (item.PropertyID)
+                {
+
+                    case 6147: //dots per inch/horizontal 
+                        string s = "";
+                        ArrayList arryres = new ArrayList();
+                        if (item.SubType == WIA.WiaSubType.FlagSubType)
+                        {
+                            s += " [valid flags include: ";
+                        }
+                        else
+                        {
+                            s += " [valid values include: ";
+                        }
+                        int count = item.SubTypeValues.Count;
+
+                        for (int i = 1; i <= count; i++)
+                        {
+                            arryres.Add(item.SubTypeValues.get_Item(i));
+                            if (i < count)
+                            {
+                                s += ", ";
+                            }
+                        }
+                        s += "]";
+
+                        if (arryres.Count > 0)
+                        {
+                            var cmbResolution = ParentForm.GetWiaResolution();
+                            cmbResolution.DataSource = arryres;
+                        }
+                        else
+                            devicescanner.resolution = (int)item.get_Value();
+                        break;
+                    case 6154: //brightness
+                        devicescanner.brightness = (int)item.get_Value();
+                        break;
+                    case 6155: //contrast
+                        devicescanner.contrast = (int)item.get_Value();
+                        break;
+                }
+            }
+
+        }
+
+        public static float MmToInch(int mm)
+        {
+            return 0.03937f * mm;
+
+        }
+
+        private WIAScanner.Scanner SetScanPropertyValues()
+        {
+            var sourceListBox = ParentForm.GetWiaSourceList();
+            var devicescanner = sourceListBox.SelectedItem as WIAScanner.Scanner;
+
+            DeviceInfo deviceproInfo;
+            deviceproInfo = deviceManager.DeviceInfos[sourceListBox.SelectedIndex + 1];
+
+            var device = deviceproInfo.Connect();
+            var deviceitem = device.Items[1];
+
+            IProperties properties = deviceitem.Properties;
+
+            SizeF documentSize = new SizeF(MmToInch(210), MmToInch(297));
+
+            var cmbColor = ParentForm.GetWiaColor();
+            var cmbResolution = ParentForm.GetWiaResolution();
+            foreach (Property item in deviceitem.Properties)
+            {
+                switch (item.PropertyID)
+                {
+                    case 6146: //4 is Black-white,gray is 2, color 1
+                        if ((cmbColor.SelectedItem != null))
+                            devicescanner.color_mode = (int)cmbColor.SelectedValue;
+                        else
+                            devicescanner.color_mode = 4;
+                        break;
+                    case 6147: //dots per inch/horizontal 
+                        if ((cmbResolution.SelectedItem != null))
+                            devicescanner.resolution = (int)cmbResolution.SelectedValue;
+                        else
+                            devicescanner.resolution = (int)item.get_Value();
+                        break;
+                    case 6148: //dots per inch/vertical 
+                        if ((cmbResolution.SelectedItem != null))
+                            devicescanner.resolution = (int)cmbResolution.SelectedValue;
+                        else
+                            devicescanner.resolution = (int)item.get_Value();
+                        break;
+                    case 6149: //x point where to start scan 
+                        devicescanner.left_pixel = (int)item.get_Value();
+                        break;
+                    case 6150: //y-point where to start scan 
+                        devicescanner.top_pixel = (int)item.get_Value();
+                        break;
+                    case 6151: //horizontal exent 
+                               //devicescanner.width_pixel = (int)(619 * devicescanner.resolution);   //  //(int)item.get_Value();
+                        devicescanner.width_pixel = (int)(documentSize.Width * devicescanner.resolution);
+                        break;
+                    case 6152: //vertical extent 
+                               //devicescanner.height_pixel = (int)(876 * devicescanner.resolution); //*  //(int)item.get_Value();
+                        devicescanner.height_pixel = (int)(documentSize.Height * devicescanner.resolution);
+                        break;
+                    case 6154: //brightness
+                        devicescanner.brightness = (int)item.get_Value();
+                        break;
+                    case 6155: //contrast
+                        devicescanner.contrast = (int)item.get_Value();
+                        break;
+                }
+            }
+            return devicescanner;
+        }
+
+        private void StartWIAScanning(string imageFormat)
+        {
+            WIAScanner.Scanner device = null;
+
+            var sourceListBox = ParentForm.GetWiaSourceList();
+            device = sourceListBox.SelectedItem as WIAScanner.Scanner;
+
+            var cmbColor = ParentForm.GetWiaColor();
+            var cmbResolution = ParentForm.GetWiaResolution();
+
+            if (device == null)
+            {
+                MessageBox.Show("You need to select first an scanner device from the list",
+                                "Warning",
+                                MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+            else if (String.IsNullOrEmpty("FileName"))
+            {
+                MessageBox.Show("Provide a filename",
+                                "Warning",
+                                MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+
+            if (String.IsNullOrEmpty(imageFormat))
+            {
+                MessageBox.Show("You need to select scan Image ",
+                               "Type",
+                               MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+
+            if (String.IsNullOrEmpty(cmbResolution.Text))
+            {
+                MessageBox.Show("You need to select a Resolution 100 is the best by default ",
+                               "Select Resolution",
+                               MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+
+            if (String.IsNullOrEmpty(cmbColor.Text))
+            {
+                MessageBox.Show("You need to select a scan color type ",
+                               "Select Color",
+                               MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+
+            var devicescanner = SetScanPropertyValues();
+
+            ImageFile image = new ImageFile();
+            ArrayList arryimage = new ArrayList();
+
+
+            ParentForm.Invoke(new MethodInvoker(delegate ()
+            {
+                switch (imageFormat)
+                {
+
+                    case "tiff":
+                        arryimage = device.ScanTIFF();
+                        imageExtension = ".tif";
+                        FileExtention = imageExtension;
+                        break;
+
+                    case "pdf":
+                        arryimage = device.ScanJPEG();
+                        imageExtension = ".jpeg";
+                        FileExtention = ".pdf";
+                        break;
+
+                    case "png":
+                        arryimage = device.ScanPNG();
+                        imageExtension = ".png";
+                        FileExtention = imageExtension;
+                        break;
+
+                    case "jpeg":
+                        arryimage = device.ScanJPEG();
+                        imageExtension = ".jpeg";
+                        FileExtention = imageExtension;
+                        break;
+                }
+            }));
+
+            int picnumber = 0;
+            for (int i = 0; i <= arryimage.Count - 1; i += 1)
+            {
+                picnumber += 1;
+                var newpic = new PictureBox();
+                System.Drawing.Image resizedImg;
+                string origPath = Path.Combine(DirText, "tmpScan" + picnumber.ToString() + "_" + i.ToString() + Guid.NewGuid().ToString() + imageExtension);
+
+                using (var img = (System.Drawing.Image)arryimage[i])
+                {
+                    newpic.Tag = origPath;
+                    switch (imageFormat)
+                    {
+                        case "tiff":
+                            img.Save(origPath, ImageFormat.Tiff);
+                            break;
+                        case "png":
+                            img.Save(origPath, ImageFormat.Png);
+                            break;
+                        case "pdf":
+                        case "jpeg":
+                        default:
+                            // pdf is just an import of a file.  Use jpg.
+                            img.Save(origPath, ImageFormat.Jpeg);
+                            break;
+                    }
+
+
+                    resizedImg = new Bitmap(img, new Size(180, 180));
+                }
+
+                newpic.Image = resizedImg;
+                newpic.Size = new Size(newpic.Image.Width, newpic.Image.Height);
+                newpic.Refresh();
+                newpic.DoubleClick += Newpic_DoubleClick;
+                newpic.MouseEnter += Newpic_MouseEnter;
+                newpic.MouseLeave += Newpic_MouseLeave;
+                var flowLayoutPanel1 = ParentForm.GetFlowLayoutPanel();
+                flowLayoutPanel1.Controls.Add(newpic);
+                newpic.Text = "ScanPass" + picnumber.ToString() + "_Pic" + picnumber.ToString();
+                flowLayoutPanel1.Controls.Add(newpic);
+                RunOcr(newpic, origPath, OcrEnabled());
+            }
+        }
+
+
+    }
+}
+#endif

--- a/TownSuite.TwainScanner/Backends/ScannerBackends.cs
+++ b/TownSuite.TwainScanner/Backends/ScannerBackends.cs
@@ -15,7 +15,7 @@ using System.Threading.Tasks;
 
 namespace TownSuite.TwainScanner.Backends
 {
-    internal class IBackend : IDisposable
+    internal class ScannerBackends : IDisposable
     {
         protected string imageFormat;
         protected readonly string DirText;
@@ -27,7 +27,7 @@ namespace TownSuite.TwainScanner.Backends
             get; set;
         }
 
-        public IBackend(string dirText, Ocr ocr)
+        public ScannerBackends(string dirText, Ocr ocr)
         {
             this.DirText = dirText;
             this.ocr = ocr;

--- a/TownSuite.TwainScanner/MainFrame.Designer.cs
+++ b/TownSuite.TwainScanner/MainFrame.Designer.cs
@@ -28,7 +28,6 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.components = new System.ComponentModel.Container();
             this.MainMenu1 = new System.Windows.Forms.MenuStrip();
             this.menuMainFile = new System.Windows.Forms.ToolStripMenuItem();
             this.MenuItem5 = new System.Windows.Forms.ToolStripMenuItem();
@@ -56,6 +55,7 @@
             this.statusStrip1 = new System.Windows.Forms.StatusStrip();
             this.toolStripProgressBar1 = new System.Windows.Forms.ToolStripProgressBar();
             this.toolStripStatusLabel1 = new System.Windows.Forms.ToolStripStatusLabel();
+            this.MainMenu1.SuspendLayout();
             this.groupBox1.SuspendLayout();
             this.tabScanDrivers.SuspendLayout();
             this.tpTWAINScan.SuspendLayout();
@@ -65,34 +65,46 @@
             // 
             // MainMenu1
             // 
-            this.MainMenu1.Items.AddRange(new System.Windows.Forms.ToolStripMenuItem[] {
+            this.MainMenu1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.menuMainFile,
             this.mnuAcquire,
             this.mnuSave});
+            this.MainMenu1.Location = new System.Drawing.Point(0, 0);
+            this.MainMenu1.Name = "MainMenu1";
+            this.MainMenu1.Size = new System.Drawing.Size(904, 24);
+            this.MainMenu1.TabIndex = 0;
             // 
             // menuMainFile
             // 
-            this.menuMainFile.MergeIndex = 0;
-            this.menuMainFile.DropDownItems.AddRange(new System.Windows.Forms.ToolStripMenuItem[] {
+            this.menuMainFile.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.MenuItem5});
             this.menuMainFile.MergeAction = System.Windows.Forms.MergeAction.Insert;
+            this.menuMainFile.MergeIndex = 0;
+            this.menuMainFile.Name = "menuMainFile";
+            this.menuMainFile.Size = new System.Drawing.Size(37, 20);
             this.menuMainFile.Text = "File";
             // 
             // MenuItem5
             // 
             this.MenuItem5.MergeIndex = 0;
+            this.MenuItem5.Name = "MenuItem5";
+            this.MenuItem5.Size = new System.Drawing.Size(92, 22);
             this.MenuItem5.Text = "Exit";
             this.MenuItem5.Click += new System.EventHandler(this.MenuItem5_Click);
             // 
             // mnuAcquire
             // 
             this.mnuAcquire.MergeIndex = 1;
+            this.mnuAcquire.Name = "mnuAcquire";
+            this.mnuAcquire.Size = new System.Drawing.Size(60, 20);
             this.mnuAcquire.Text = "&Acquire";
             this.mnuAcquire.Click += new System.EventHandler(this.mnuAcquire_Click);
             // 
             // mnuSave
             // 
             this.mnuSave.MergeIndex = 2;
+            this.mnuSave.Name = "mnuSave";
+            this.mnuSave.Size = new System.Drawing.Size(43, 20);
             this.mnuSave.Text = "&Save";
             this.mnuSave.Click += new System.EventHandler(this.mnuSave_Click);
             // 
@@ -104,7 +116,7 @@
             this.flowLayoutPanel1.AutoScroll = true;
             this.flowLayoutPanel1.Location = new System.Drawing.Point(186, 0);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-            this.flowLayoutPanel1.Size = new System.Drawing.Size(586, 474);
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(710, 593);
             this.flowLayoutPanel1.TabIndex = 0;
             // 
             // sourceListBox
@@ -202,11 +214,12 @@
             // 
             this.tabScanDrivers.Controls.Add(this.tpTWAINScan);
             this.tabScanDrivers.Controls.Add(this.tpWIAScan);
-            this.tabScanDrivers.Location = new System.Drawing.Point(6, 2);
+            this.tabScanDrivers.Location = new System.Drawing.Point(6, 27);
             this.tabScanDrivers.Name = "tabScanDrivers";
             this.tabScanDrivers.SelectedIndex = 0;
-            this.tabScanDrivers.Size = new System.Drawing.Size(174, 472);
+            this.tabScanDrivers.Size = new System.Drawing.Size(174, 447);
             this.tabScanDrivers.TabIndex = 7;
+            this.tabScanDrivers.SelectedIndexChanged += new System.EventHandler(this.tabScanDrivers_SelectedIndexChanged);
             // 
             // tpTWAINScan
             // 
@@ -218,7 +231,7 @@
             this.tpTWAINScan.Location = new System.Drawing.Point(4, 22);
             this.tpTWAINScan.Name = "tpTWAINScan";
             this.tpTWAINScan.Padding = new System.Windows.Forms.Padding(3);
-            this.tpTWAINScan.Size = new System.Drawing.Size(166, 446);
+            this.tpTWAINScan.Size = new System.Drawing.Size(166, 421);
             this.tpTWAINScan.TabIndex = 1;
             this.tpTWAINScan.Text = "TWAIN";
             this.tpTWAINScan.UseVisualStyleBackColor = true;
@@ -240,7 +253,7 @@
             this.buttonTwainScan.Name = "buttonTwainScan";
             this.buttonTwainScan.Size = new System.Drawing.Size(75, 23);
             this.buttonTwainScan.TabIndex = 11;
-            this.buttonTwainScan.Text = I18N.GetString("Scan");
+            this.buttonTwainScan.Text = "Scan";
             this.buttonTwainScan.UseVisualStyleBackColor = true;
             this.buttonTwainScan.Click += new System.EventHandler(this.ButtonTwainScan_Click);
             // 
@@ -285,7 +298,7 @@
             this.tpWIAScan.Location = new System.Drawing.Point(4, 22);
             this.tpWIAScan.Name = "tpWIAScan";
             this.tpWIAScan.Padding = new System.Windows.Forms.Padding(3);
-            this.tpWIAScan.Size = new System.Drawing.Size(166, 446);
+            this.tpWIAScan.Size = new System.Drawing.Size(166, 421);
             this.tpWIAScan.TabIndex = 0;
             this.tpWIAScan.Text = "WIA";
             this.tpWIAScan.UseVisualStyleBackColor = true;
@@ -306,9 +319,9 @@
             this.statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripProgressBar1,
             this.toolStripStatusLabel1});
-            this.statusStrip1.Location = new System.Drawing.Point(0, 477);
+            this.statusStrip1.Location = new System.Drawing.Point(0, 596);
             this.statusStrip1.Name = "statusStrip1";
-            this.statusStrip1.Size = new System.Drawing.Size(780, 22);
+            this.statusStrip1.Size = new System.Drawing.Size(904, 22);
             this.statusStrip1.TabIndex = 8;
             this.statusStrip1.Text = "statusStrip1";
             // 
@@ -329,7 +342,7 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(780, 499);
+            this.ClientSize = new System.Drawing.Size(904, 618);
             this.Controls.Add(this.MainMenu1);
             this.Controls.Add(this.statusStrip1);
             this.Controls.Add(this.tabScanDrivers);
@@ -339,6 +352,9 @@
             this.Text = "Scan Document";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.MainFrame_FormClosing);
             this.Load += new System.EventHandler(this.MainFrame_Load);
+            this.Shown += new System.EventHandler(this.MainFrame_Shown);
+            this.MainMenu1.ResumeLayout(false);
+            this.MainMenu1.PerformLayout();
             this.groupBox1.ResumeLayout(false);
             this.groupBox1.PerformLayout();
             this.tabScanDrivers.ResumeLayout(false);

--- a/TownSuite.TwainScanner/MainFrame.cs
+++ b/TownSuite.TwainScanner/MainFrame.cs
@@ -7,48 +7,45 @@ using System.IO;
 using System.Windows.Forms;
 using System.Linq;
 using System.Collections;
-#if INCLUDE_WIA
-using WIA;
-#endif
+
 using System.Threading;
 using System.Text.RegularExpressions;
 using System.Windows.Media;
 using iTextSharp.text;
 using iTextSharp.text.pdf;
+using TownSuite.TwainScanner.Backends;
 namespace TownSuite.TwainScanner
 {
     internal partial class MainFrame : Form
     {
-        private Twain32 _twain;
-
-        readonly string DirText;
-#if INCLUDE_WIA
-        private DeviceManager deviceManager;
-        bool removeWia = false;
-#else
-        bool removeWia = true;
-#endif
-        private string FileExtention;
-        private string imageExtension = "";
         private List<String> lstscansettings;
         private string UserTwainImageType;
         private string UserTwainScanner;
         readonly Ocr ocr;
+        IBackend backend;
+        readonly string dirText;
 
-        public MainFrame(List<String> lstScanSet, Ocr ocr, string workingDir)
+#if INCLUDE_WIA
+        bool removeWia = false;
+#else
+        bool removeWia = true;
+#endif
+
+        public MainFrame(List<String> lstScanSet, Ocr ocr, string dirText, string backend)
         {
             lstscansettings = lstScanSet;
             this.ocr = ocr;
-            DirText = Path.Combine(workingDir,"TownSuiteScanner");
+            this.dirText = dirText;
+
             InitializeComponent();
+
+            // this.backend = GetBackend(backend);
+            //this.backend.DeleteFiles();
+
         }
 
         private void MainFrame_Load(object sender, EventArgs e)
         {
-            if (!System.IO.Directory.Exists(DirText))
-            {
-                System.IO.Directory.CreateDirectory(DirText);
-            }
 
             for (int i = 0; i <= lstscansettings.Count - 1; i++)
             {
@@ -62,7 +59,10 @@ namespace TownSuite.TwainScanner
                         break;
                 }
             }
+        }
 
+        private void MainFrame_Shown(object sender, EventArgs e)
+        {
             try
             {
                 if (removeWia)
@@ -70,10 +70,10 @@ namespace TownSuite.TwainScanner
                     tabScanDrivers.TabPages.RemoveByKey("tpWIAScan");
                 }
 
+                ChangeBackend();
+                this.backend.DeleteFiles();
+                // backend.ConfigureSettings();
 
-                _twain = new Twain32();
-                this._twain.AcquireCompleted += new System.EventHandler(this._twain_AcquireCompleted);
-                this._twain.OpenDSM();
 
             }
             catch (TwainException ex)
@@ -82,41 +82,20 @@ namespace TownSuite.TwainScanner
                 {
                     Console.WriteLine("Failed to find a scanner");
                     Console.Out.Flush();
-                    //     this.Close();
-                    //   return;
+                    this.Close();
+                    return;
                 }
-                //  throw;
+                throw;
             }
             catch (Exception ex)
             {
                 MessageBox.Show(string.Format("{0}\n\n{1}", ex.Message, ex.StackTrace), I18N.GetString("LoadError"), MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
 
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-
-            DeleteFiles();
-
-            LoadTwainDrivers();
-#if INCLUDE_WIA
-            LoadWIADrivers();
-            GetColors();
-#endif
-
             //Set Default Twain Scanner Settings
             cmbTwainImageType.SelectedItem = UserTwainImageType;
             sourceTwianListBox.SelectedItem = UserTwainScanner;
             //cmbTwainImageType.SelectedIndex = 0;
-
-#if INCLUDE_WIA
-            //WIA Settings
-            cmbImageType.SelectedIndex = 0;
-            cmbColor.SelectedIndex = 0;
-
-            cmbColor.DropDownStyle = ComboBoxStyle.DropDownList;
-            cmbResolution.DropDownStyle = ComboBoxStyle.DropDownList;
-
-#endif
 
             checkBoxTwainOcr.Visible = ocr.Enabled;
             checkboxWiaOcr.Visible = ocr.Enabled;
@@ -124,43 +103,7 @@ namespace TownSuite.TwainScanner
 
         #region Delete Temporary Files
 
-        private void DeleteFiles()
-        {
 
-            if (string.Equals(DirText, System.IO.Path.Combine(Environment.GetEnvironmentVariable("TMP"), "TownSuite", "TwainScanner"), 
-                StringComparison.InvariantCultureIgnoreCase))
-            {
-                // using a custom folder.   Delete everything.
-                LoopFiles("*.bmp");
-                LoopFiles("*.jpeg");
-                LoopFiles("*.tif");
-                LoopFiles("*.png");
-                LoopFiles("*.pdf");
-                LoopFiles("*.txt");
-            }
-            else
-            {
-                LoopFiles("tmpscan*.bmp");
-                LoopFiles("tmpscan*.jpeg");
-                LoopFiles("tmpscan*.tif");
-                LoopFiles("tmpscan*.png");
-                LoopFiles("tmpscan*.pdf");
-                LoopFiles("tmpscan*.txt");
-            }
-        }
-
-        private void LoopFiles(string fileext)
-        {
-            //New Stuff
-            //---------------------------
-            string [] sa = Directory.GetFiles(DirText, fileext);
-
-            foreach (string s_loopVariable in sa)
-            {
-                string s = s_loopVariable;
-                File.Delete(s);
-            }
-        }
 
         #endregion
 
@@ -168,41 +111,6 @@ namespace TownSuite.TwainScanner
         {
             this.Close();
         }
-
-        #region Load Twian Drivers
-
-        public Twain32 Twain
-        {
-            get;
-            set;
-        }
-
-        private void LoadTwainDrivers()
-        {
-            try
-            {
-                this.sourceTwianListBox.Items.Clear();
-                //this._twain.CloseDataSource();
-                //this._twain.SelectSource();
-                Twain = this._twain;
-
-                if (this.Twain != null && this.Twain.SourcesCount > 0)
-                {
-                    for (int i = 0; i < this.Twain.SourcesCount; i++)
-                    {
-                        bool twn2 = this.Twain.GetIsSourceTwain2Compatible(i);
-                        this.sourceTwianListBox.Items.Add(this.Twain.GetSourceProductName(i));
-                    }
-                    this.sourceTwianListBox.SelectedIndex = this.Twain.SourceIndex;
-                }
-
-            }
-            catch (Exception ex)
-            {
-                MessageBox.Show(ex.Message, ex.GetType().Name, MessageBoxButtons.OK, MessageBoxIcon.Error);
-            }
-        }
-        #endregion
 
         #region WIA Drivers
 
@@ -212,503 +120,24 @@ namespace TownSuite.TwainScanner
             //Start Scanning using a Thread
             //Task.Factory.StartNew(StartScanning).ContinueWith(result => TriggerScan());
 
-            StartWIAScanning();
+            string imageFormat = GetSelectedWiaImageFormat();
+            backend.Scan(imageFormat);
 #endif
 
         }
-
-#if INCLUDE_WIA
-        private void LoadWIADrivers()
-        {
-            // Clear the ListBox.
-            sourceListBox.Items.Clear();
-
-            // Create a DeviceManager instance
-            deviceManager = new DeviceManager();
-
-
-            // Loop through the list of devices and add the name to the listbox
-            for (int i = 1; i <= deviceManager.DeviceInfos.Count; i++)
-            {
-                // Add the device only if it's a scanner
-                if (deviceManager.DeviceInfos[i].Type != WiaDeviceType.ScannerDeviceType)
-                {
-                    continue;
-                }
-
-                // Add the Scanner device to the listbox (the entire DeviceInfos object)
-                // Important: we store an object of type scanner (which ToString method returns the name of the scanner)
-                sourceListBox.Items.Add(
-                    new WIAScanner.Scanner(deviceManager.DeviceInfos[i])
-                );
-            }
-        }
-
-        private WIA.Device DoSomething(DeviceInfo deviceproInfo)
-        {
-            try
-            {
-                WIA.Device device = deviceproInfo.Connect();
-                return device;
-            }
-            catch (ThreadAbortException)
-            {
-                // cleanup code, if needed...
-                return null;
-            }
-        }
-
-        public void LoadScanPropertyValues() // async Task
-        {
-            var devicescanner = sourceListBox.SelectedItem as WIAScanner.Scanner;
-            if (devicescanner == null)
-            {
-                return;
-            }
-
-            WIA.Device device = null;
-            
-            DeviceInfo deviceproInfo;
-            deviceproInfo = deviceManager.DeviceInfos[sourceListBox.SelectedIndex + 1];
-
-            Thread t = new Thread(() => { device = DoSomething(deviceproInfo); });
-            t.Start();
-            if (!t.Join(TimeSpan.FromSeconds(5)))
-            {
-                t.Abort();
-                throw new Exception("More than 5 secs.");
-            }
-
-
-            // device = ConnectWIA();
-
-            //--------------------------------------------------
-            var deviceitem = device.Items[1];
-
-            IProperties properties;
-            properties = deviceitem.Properties;
-
-            foreach (Property item in deviceitem.Properties)
-            {
-                switch (item.PropertyID)
-                {
-
-                    case 6147: //dots per inch/horizontal 
-                        string s = "";
-                        ArrayList arryres = new ArrayList();
-                        if (item.SubType == WIA.WiaSubType.FlagSubType)
-                        {
-                            s += " [valid flags include: ";
-                        }
-                        else
-                        {
-                            s += " [valid values include: ";
-                        }
-                        int count = item.SubTypeValues.Count;
-
-                        for (int i = 1; i <= count; i++)
-                        {
-                            arryres.Add(item.SubTypeValues.get_Item(i));
-                            if (i < count)
-                            {
-                                s += ", ";
-                            }
-                        }
-                        s += "]";
-
-                        if (arryres.Count > 0)
-                            cmbResolution.DataSource = arryres;
-                        else
-                            devicescanner.resolution = (int)item.get_Value();
-                        break;
-                    case 6154: //brightness
-                        devicescanner.brightness = (int)item.get_Value();
-                        break;
-                    case 6155: //contrast
-                        devicescanner.contrast = (int)item.get_Value();
-                        break;
-                }
-            }
-
-        }
-
-        public static float MmToInch(int mm)
-        {
-            return 0.03937f * mm;
-
-        }
-
-        private WIAScanner.Scanner SetScanPropertyValues()
-        {
-
-            var devicescanner = sourceListBox.SelectedItem as WIAScanner.Scanner;
-
-            DeviceInfo deviceproInfo;
-            deviceproInfo = deviceManager.DeviceInfos[sourceListBox.SelectedIndex + 1];
-
-            var device = deviceproInfo.Connect();
-            var deviceitem = device.Items[1];
-
-            IProperties properties = deviceitem.Properties;
-
-            SizeF documentSize = new SizeF(MmToInch(210), MmToInch(297));
-
-            foreach (Property item in deviceitem.Properties)
-            {
-                switch (item.PropertyID)
-                {
-                    case 6146: //4 is Black-white,gray is 2, color 1
-                        if ((cmbColor.SelectedItem != null))
-                            devicescanner.color_mode = (int)cmbColor.SelectedValue;
-                        else
-                            devicescanner.color_mode = 4;
-                        break;
-                    case 6147: //dots per inch/horizontal 
-                        if ((cmbResolution.SelectedItem != null))
-                            devicescanner.resolution = (int)cmbResolution.SelectedValue;
-                        else
-                            devicescanner.resolution = (int)item.get_Value();
-                        break;
-                    case 6148: //dots per inch/vertical 
-                        if ((cmbResolution.SelectedItem != null))
-                            devicescanner.resolution = (int)cmbResolution.SelectedValue;
-                        else
-                            devicescanner.resolution = (int)item.get_Value();
-                        break;
-                    case 6149: //x point where to start scan 
-                        devicescanner.left_pixel = (int)item.get_Value();
-                        break;
-                    case 6150: //y-point where to start scan 
-                        devicescanner.top_pixel = (int)item.get_Value();
-                        break;
-                    case 6151: //horizontal exent 
-                               //devicescanner.width_pixel = (int)(619 * devicescanner.resolution);   //  //(int)item.get_Value();
-                        devicescanner.width_pixel = (int)(documentSize.Width * devicescanner.resolution);
-                        break;
-                    case 6152: //vertical extent 
-                               //devicescanner.height_pixel = (int)(876 * devicescanner.resolution); //*  //(int)item.get_Value();
-                        devicescanner.height_pixel = (int)(documentSize.Height * devicescanner.resolution);
-                        break;
-                    case 6154: //brightness
-                        devicescanner.brightness = (int)item.get_Value();
-                        break;
-                    case 6155: //contrast
-                        devicescanner.contrast = (int)item.get_Value();
-                        break;
-                }
-            }
-            return devicescanner;
-        }
-
-        public void StartWIAScanning()
-        {
-            WIAScanner.Scanner device = null;
-
-            this.Invoke(new MethodInvoker(delegate ()
-            {
-                device = sourceListBox.SelectedItem as WIAScanner.Scanner;
-            }));
-
-
-            if (device == null)
-            {
-                MessageBox.Show("You need to select first an scanner device from the list",
-                                "Warning",
-                                MessageBoxButtons.OK, MessageBoxIcon.Warning);
-                return;
-            }
-            else if (String.IsNullOrEmpty("FileName"))
-            {
-                MessageBox.Show("Provide a filename",
-                                "Warning",
-                                MessageBoxButtons.OK, MessageBoxIcon.Warning);
-                return;
-            }
-
-            if (String.IsNullOrEmpty(cmbImageType.Text))
-            {
-                MessageBox.Show("You need to select scan Image ",
-                               "Type",
-                               MessageBoxButtons.OK, MessageBoxIcon.Warning);
-                return;
-            }
-
-            if (String.IsNullOrEmpty(cmbResolution.Text))
-            {
-                MessageBox.Show("You need to select a Resolution 100 is the best by default ",
-                               "Select Resolution",
-                               MessageBoxButtons.OK, MessageBoxIcon.Warning);
-                return;
-            }
-
-            if (String.IsNullOrEmpty(cmbColor.Text))
-            {
-                MessageBox.Show("You need to select a scan color type ",
-                               "Select Color",
-                               MessageBoxButtons.OK, MessageBoxIcon.Warning);
-                return;
-            }
-
-            var devicescanner = SetScanPropertyValues();
-
-            ImageFile image = new ImageFile();
-            ArrayList arryimage = new ArrayList();
-
-
-            string wiaImageFormat="jpeg";
-     
-            wiaImageFormat = GetSelectedWiaImageFormat().ToLower().Trim();
-            this.Invoke(new MethodInvoker(delegate ()
-            {
-                switch (wiaImageFormat)
-            {
-
-                case "tiff":
-                    arryimage = device.ScanTIFF();
-                    imageExtension = ".tif";
-                    FileExtention = imageExtension;
-                    break;
-
-                case "pdf":
-                    arryimage = device.ScanJPEG();
-                    imageExtension = ".jpeg";
-                    FileExtention = ".pdf";
-                    break;
-
-                case "png":
-                    arryimage = device.ScanPNG();
-                    imageExtension = ".png";
-                    FileExtention = imageExtension;
-                    break;
-
-                case "jpeg":
-                    arryimage = device.ScanJPEG();
-                    imageExtension = ".jpeg";
-                    FileExtention = imageExtension;
-                    break;
-            }
-            }));
-
-            for (int i = 0; i <= arryimage.Count - 1; i += 1)
-            {
-                picnumber += 1;
-                var newpic = new PictureBox();
-                System.Drawing.Image resizedImg;
-                string origPath = Path.Combine(DirText, "tmpScan" + picnumber.ToString() + "_" + i.ToString() + Guid.NewGuid().ToString() + imageExtension);
-
-                using (var img = (System.Drawing.Image)arryimage[i])
-                {
-                    newpic.Tag = origPath;
-                    switch (wiaImageFormat)
-                    {
-                        case "tiff":
-                            img.Save(origPath, ImageFormat.Tiff);
-                            break;
-                        case "png":
-                            img.Save(origPath, ImageFormat.Png);
-                            break;
-                        case "pdf":
-                        case "jpeg":
-                        default:
-                            // pdf is just an import of a file.  Use jpg.
-                            img.Save(origPath, ImageFormat.Jpeg);
-                            break;
-                    }
-
-
-                    resizedImg = new Bitmap(img, new Size(180, 180));
-                }
-
-                newpic.Image = resizedImg;
-                newpic.Size = new Size(newpic.Image.Width, newpic.Image.Height);
-                newpic.Refresh();
-                newpic.DoubleClick += Newpic_DoubleClick;
-                newpic.MouseEnter += Newpic_MouseEnter;
-                newpic.MouseLeave += Newpic_MouseLeave;
-                flowLayoutPanel1.Controls.Add(newpic);
-                newpic.Text = "ScanPass" + picnumber.ToString() + "_Pic" + picnumber.ToString();
-
-                RunOcr(newpic, origPath, checkboxWiaOcr.Checked);
-            }
-        }
- 
-#endif
         #endregion
 
-        private void RunOcr(PictureBox newpic, string origPath, bool ocrCheckboxChecked)
-        {
-            if (ocr.Enabled && ocrCheckboxChecked)
-            {
-                ocr.GetText(origPath, newpic, toolStripProgressBar1, toolStripStatusLabel1);
-            }
-        }
-
-        private void Newpic_MouseLeave(object sender, EventArgs e)
-        {
-            if (sender is PictureBox == false)
-            {
-                return;
-            }
-            var pb = sender as PictureBox;
-            pb.BorderStyle = BorderStyle.None;
-        }
-
-        private void Newpic_MouseEnter(object sender, EventArgs e)
-        {
-            if (sender is PictureBox == false)
-            {
-                return;
-            }
-            var pb = sender as PictureBox;
-            pb.BorderStyle = BorderStyle.FixedSingle;
-        }
-
-        private void Newpic_DoubleClick(object sender, EventArgs e)
-        {
-            if (sender is PictureBox == false)
-            {
-                return;
-            }
-            var pb = sender as PictureBox;
-            if (System.IO.File.Exists(pb.Tag?.ToString() ?? ""))
-            {
-                System.Diagnostics.Process.Start(pb.Tag.ToString());
-            }
-        }
-
-        private void GetColors()
-        {
-            DataTable dtColors = new DataTable();
-            DataColumn newColType = new DataColumn("Type", typeof(String));
-            DataColumn newColCode = new DataColumn("Code", typeof(int));
-            dtColors.Columns.Add(newColType);
-            dtColors.Columns.Add(newColCode);
-            dtColors.Rows.Add(new object[] { "Color", 1 });
-            dtColors.Rows.Add(new object[] { "Grayscale", 2 });
-            dtColors.Rows.Add(new object[] { "Black & White", 4 });
-
-            cmbColor.DisplayMember = "Type";
-            cmbColor.ValueMember = "Code";
-            cmbColor.DataSource = dtColors;
-        }
 
         private void mnuAcquire_Click(object sender, EventArgs e)
         {
             try
             {
-                switch (tabScanDrivers.SelectedTab.Name)
-                {
-#if INCLUDE_WIA
-                    case "tpWIAScan":
-                        StartWIAScanning();
-                        break;
-#endif
-                    case "tpTWAINScan":
-                        StartTWIAScanning();
-                        break;
-                }
+                string imageFormat = GetSelectedTwainImageFormat().ToLower().Trim();
+                backend.Scan(imageFormat);
             }
             catch (Exception ex)
             {
                 MessageBox.Show(ex.Message, I18N.GetString("ScanningError"), MessageBoxButtons.OK, MessageBoxIcon.Error);
-            }
-        }
-
-        public void StartTWIAScanning()
-        {
-
-            if (String.IsNullOrEmpty(cmbTwainImageType.Text))
-            {
-                MessageBox.Show(I18N.GetString("SelectScanImage"),
-                               "type",
-                               MessageBoxButtons.OK, MessageBoxIcon.Warning);
-                return;
-            }
-
-            string imageForat = GetSelectedTwainImageFormat().ToLower().Trim();
-            switch (imageForat)
-            {
-                case "tiff":
-                    FileExtention = ".tif";
-                    imageExtension = ".tif";
-                    break;
-                case "png":
-                    // PDFs will internally be png images
-                    FileExtention = ".png";
-                    imageExtension = ".png";
-                    break;
-                case "pdf":
-                    FileExtention = ".pdf";
-                    imageExtension = ".jpeg";
-                    break;
-                case "jpeg":
-                    FileExtention = ".jpeg";
-                    imageExtension = ".jpeg";
-                    break;
-            }
-
-            this._twain.Acquire();
-        }
-
-        int picnumber = 0;
-
-        private void _twain_AcquireCompleted(object sender, EventArgs e)
-        {
-            try
-            {
-                if (this._twain.ImageCount > 0)
-                {
-
-                    string imageForat = GetSelectedTwainImageFormat().ToLower().Trim();
-
-                    
-                    for (int i = 0; i <= this._twain.ImageCount - 1; i += 1)
-                    {
-                        picnumber += 1;
-                        var newpic = new PictureBox();
-                        System.Drawing.Image resizedImg;
-                        string origPath = Path.Combine(DirText, "tmpScan" + picnumber.ToString() + "_" + i.ToString() + Guid.NewGuid().ToString() + imageExtension);
-                        newpic.Tag = origPath;
-                        using (var img = this._twain.GetImage(i))
-                        {
-                            switch (imageForat)
-                            {
-                                case "tiff":
-                                    img.Save(origPath, ImageFormat.Tiff);
-                                    break;
-                                case "png":
-                                    img.Save(origPath, ImageFormat.Png);
-                                    break;
-                                case "pdf":
-                                case "jpeg":
-                                default:
-                                    // pdf is just an import of a file.  Use jpg.
-                                    img.Save(origPath, ImageFormat.Jpeg);
-                                    break;
-                            }
-
-                            resizedImg = new Bitmap(img, new Size(180, 180));
-                        }
-
-                        newpic.Image = resizedImg;
-                        newpic.Size = new Size(newpic.Image.Width, newpic.Image.Height);
-                        newpic.Refresh();
-                        newpic.DoubleClick += Newpic_DoubleClick;
-                        newpic.MouseEnter += Newpic_MouseEnter;
-                        newpic.MouseLeave += Newpic_MouseLeave;
-                        flowLayoutPanel1.Controls.Add(newpic);
-                        newpic.Text = "ScanPass" + picnumber.ToString() + "_Pic" + picnumber.ToString();
-
-                        // newpic.doTmpSave(DirText + "\\tmpScan" + picnumber.ToString() + "_" + i.ToString() + ".bmp");
-
-                        RunOcr(newpic, origPath, checkBoxTwainOcr.Checked);
-                    }
-
-                }
-            }
-            catch (Exception ex)
-            {
-                MessageBox.Show(ex.Message, I18N.GetString("TownSuiteScan"), MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 
@@ -718,423 +147,52 @@ namespace TownSuite.TwainScanner
         {
             try
             {
-                switch (tabScanDrivers.SelectedTab.Name)
-                {
-                    case "tpTWAINScan":
-                        string twainImageFormat = GetSelectedTwainImageFormat().ToLower().Trim();
-                        switch (twainImageFormat)
-                        {
-                            case "tiff":
-                                //Save tiff
-                                SaveTWAIN_TIFF();
-                                break;
-                            case "png":
-                                SavePNG();
-                                break;
-                            case "jpeg":
-                                SaveJPEG();
-                                break;
-                            case "pdf":
-                                //Save pdf
-                                SavePDF();
-                                break;
-                        }
-                        break;
-                    case "tpWIAScan":
-                        string wiaImageFormat = GetSelectedWiaImageFormat().ToLower().Trim();
-                        switch (wiaImageFormat)
-                        {
-                            case "tiff":
-                                //Save tiff
-                                SaveTIFF();
-                                break;
-                            case "pdf":
-                                //Save pdf
-                                SavePDF();
-                                break;
-                            case "png":
-                                //Save PNG'
-                                SavePNG();
-                                break;
-                            case "jpeg":
-                                //Save Jepg
-                                SaveJPEG();
-                                break;
-                        }
-                        break;
-                }
-
-                Console.WriteLine();
-                Console.WriteLine(" " + FileExtention + " ");
-                Console.WriteLine();
-                Console.WriteLine("SAVED");
-                Console.Out.Flush();
-
+                backend.Save();
                 this.DialogResult = DialogResult.OK;
                 this.Close();
             }
             catch (Exception ex)
             {
-                MessageBox.Show(I18N.GetString("ErrorOccured") + "\r\n" + ex.Message, 
+                MessageBox.Show(I18N.GetString("ErrorOccured") + "\r\n" + ex.Message,
                     I18N.GetString("ScanDocument"), MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 
-        #region Save Twian Files
-
-        public static string PadNumbers(string input)
-        {
-            string smallName = System.IO.Path.GetFileNameWithoutExtension(input);
-            // Default ordering for a string is standard alpha numeric dictionary ordering.
-            // when individual files like tmpScan1_0.bmp , tmpScan2_1.bmp .....tmpScan10_9.bmp, tmpScan11_10
-            //Then tmpScan1_0.bmp will be first and order the files and tmpScan10_9.bmp, tmpScan11_10 after
-            return Regex.Replace(smallName, "[0-9]+", match => match.Value.PadLeft(10, '0'));
-        }
-
-        private void SaveTWAIN_TIFF()
-        {
-            string[] sa = null;
-            sa = Directory.GetFiles(DirText, "tmpscan*.tif");
-
-            List<string> UnSortList = new List<string>(sa);
-            List<string> SortedList = UnSortList.OrderBy(p => PadNumbers(p)).ToList();
-            sa = SortedList.ToArray();
-
-            //get the codec for tiff files
-            ImageCodecInfo info = ImageCodecInfo.GetImageEncoders().Where(p => p.MimeType == "image/tiff").FirstOrDefault();
-
-            //use the save encoder
-            var enc = System.Drawing.Imaging.Encoder.SaveFlag;
-            EncoderParameters ep = new EncoderParameters(1);
-
-            ep.Param[0] = new EncoderParameter(enc, Convert.ToInt64(EncoderValue.MultiFrame));
-
-            Bitmap pages = null;
-            int frame = 0;
-
-            foreach (string s in sa)
-            {
-                if (frame == 0)
-                {
-                    pages = (Bitmap)System.Drawing.Image.FromFile(s);
-
-                    //save the first frame
-                    pages.Save(Path.Combine(DirText, "tmpScan.tif"), info, ep);
-                }
-                else
-                {
-                    //save the intermediate frames
-                    ep.Param[0] = new EncoderParameter(enc, Convert.ToInt64(EncoderValue.FrameDimensionPage));
-                    using (Bitmap bm = (Bitmap)System.Drawing.Image.FromFile(s))
-                    {
-                        pages.SaveAdd(bm, ep);
-                    }
-                }
-                if (frame == sa.Length - 1)
-                {
-                    //flush and close.
-                    ep.Param[0] = new EncoderParameter(enc, Convert.ToInt64(EncoderValue.Flush));
-                    pages.SaveAdd(ep);
-
-                }
-                frame += 1;
-
-            }
-        }
-
-        #endregion
-
-        private string SaveJPEG()
-        {
-            string[] inputFiles = Directory.GetFiles(DirText, "tmpscan*.jpeg");
-
-            // TODO: You may want to add input checking here.
-            System.Drawing.Image[] images = new System.Drawing.Image[inputFiles.Length];
-            System.Drawing.Image image;
-            int height = 0, width = 0;
-
-            try
-            {
-                for (int i = 0; i < inputFiles.Length; ++i)
-                {
-                    images[i] = image = System.Drawing.Image.FromFile(inputFiles[i]);
-                    height = Math.Max(height, image.Height);
-                    width += image.Width;
-                }
-
-                image = new Bitmap(width, height, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
-
-                using (Graphics g = Graphics.FromImage(image))
-                {
-                    // Clear the background to transparent.
-                    g.Clear(System.Drawing.Color.Transparent);
-
-                    width = 0;
-
-                    for (int i = 0; i < images.Length; ++i)
-                    {
-                        double scale = (double)height / images[i].Height;
-                        int scaledWidth = (int)(images[i].Width * scale);
-                        // Draw the image scaled to match the maxHeight
-                        g.DrawImage(images[i],
-                                    new System.Drawing.Rectangle(width, 0, scaledWidth, height),
-                                    new System.Drawing.Rectangle(0, 0, images[i].Width, images[i].Height),
-                                    GraphicsUnit.Pixel);
-                        width += scaledWidth;
-
-                        // free memory immediately to avoid out of memory exception as 'image' grows.
-                        if (images[i] != null)
-                            images[i].Dispose();
-                    }
-                }
-                    image.Save(Path.Combine(DirText, "tmpScan.jpeg"));
-                //imageLocation.Image = image;
-            }
-            finally
-            {
-                // in case of exception dispose everything properly
-                for (int i = 0; i < inputFiles.Length; ++i)
-                    if (images[i] != null)
-                        images[i].Dispose();
-            }
-
-            return "";
-        }
-
-        private void SaveTIFF()
-        {
-            string[] sa = null;
-            sa = Directory.GetFiles(DirText, "tmpscan*.tif");
-
-            List<string> UnSortList = new List<string>(sa);
-            List<string> SortedList = UnSortList.OrderBy(p => PadNumbers(p)).ToList();
-            sa = SortedList.ToArray();
-
-            //get the codec for tiff files
-            ImageCodecInfo info = ImageCodecInfo.GetImageEncoders().Where(p => p.MimeType == "image/tiff").FirstOrDefault();
-
-            //use the save encoder
-            var enc = System.Drawing.Imaging.Encoder.SaveFlag;
-            EncoderParameters ep = new EncoderParameters(1);
-
-            ep.Param[0] = new EncoderParameter(enc, Convert.ToInt64(EncoderValue.MultiFrame));
-
-            Bitmap pages = null;
-            int frame = 0;
-
-            foreach (string s in sa)
-            {
-                if (frame == 0)
-                {
-                    pages = (Bitmap)System.Drawing.Image.FromFile(s);
-
-                    //save the first frame
-                    pages.Save(DirText + "\\tmpScan.tif", info, ep);
-                }
-                else
-                {
-                    //save the intermediate frames
-                    ep.Param[0] = new EncoderParameter(enc, Convert.ToInt64(EncoderValue.FrameDimensionPage));
-                    using (Bitmap bm = (Bitmap)System.Drawing.Image.FromFile(s))
-                    {
-                        pages.SaveAdd(bm, ep);
-                    }
-                }
-                if (frame == sa.Length - 1)
-                {
-                    //flush and close.
-                    ep.Param[0] = new EncoderParameter(enc, Convert.ToInt64(EncoderValue.Flush));
-                    pages.SaveAdd(ep);
-
-                }
-                frame += 1;
-
-            }
-        }
-
-        private string SavePNG()
-        {
-            string[] inputFiles = Directory.GetFiles(DirText, "tmpscan*.png");
-
-            // TODO: You may want to add input checking here.
-            System.Drawing.Image[] images = new System.Drawing.Image[inputFiles.Length];
-            System.Drawing.Image image;
-            int height = 0, width = 0;
-
-            try
-            {
-                for (int i = 0; i < inputFiles.Length; ++i)
-                {
-                    images[i] = image = System.Drawing.Image.FromFile(inputFiles[i]);
-                    height = Math.Max(height, image.Height);
-                    width += image.Width;
-                }
-
-                image = new Bitmap(width, height, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
-
-                using (Graphics g = Graphics.FromImage(image))
-                {
-                    // Clear the background to transparent.
-                    g.Clear(System.Drawing.Color.Transparent);
-
-                    width = 0;
-
-                    for (int i = 0; i < images.Length; ++i)
-                    {
-                        double scale = (double)height / images[i].Height;
-                        int scaledWidth = (int)(images[i].Width * scale);
-                        // Draw the image scaled to match the maxHeight
-                        g.DrawImage(images[i],
-                                    new System.Drawing.Rectangle(width, 0, scaledWidth, height),
-                                    new System.Drawing.Rectangle(0, 0, images[i].Width, images[i].Height),
-                                    GraphicsUnit.Pixel);
-                        width += scaledWidth;
-
-                        // free memory immediately to avoid out of memory exception as 'image' grows.
-                        if (images[i] != null)
-                            images[i].Dispose();
-                    }
-                }
-
-                // You don't need to save this in order to use the in-memory object.
-                // img3.Save(finalImage, System.Drawing.Imaging.ImageFormat.Jpeg);
-
-                image.Save(Path.Combine(DirText, "tmpScan.png"));
-                //imageLocation.Image = image;
-            }
-            finally
-            {
-                // in case of exception dispose everything properly
-                for (int i = 0; i < inputFiles.Length; ++i)
-                    images[i]?.Dispose();
-            }
-
-            return "";
-        }
-
-        private void SavePDF()
-        {
-            var predefinedSizes = new[]
-        {
-            new { Size = PageSize.A4, Width = 21f, Height = 29.7f },
-            new { Size = PageSize.A3, Width = 29.7f, Height = 42f },
-            new { Size = new iTextSharp.text.Rectangle(21.59f * 28.35f, 27.94f * 28.35f), Width = 21.59f, Height = 27.94f },  // Letter (8.5" x 11")
-            new { Size = new iTextSharp.text.Rectangle(21.59f * 28.35f, 35.56f * 28.35f), Width = 21.59f, Height = 35.56f },  // Legal (8.5" x 14")
-            new { Size = new iTextSharp.text.Rectangle(15.24f * 28.35f, 6.99f * 28.35f), Width = 15.24f, Height = 6.99f },  // Cheque: 6" x 2.75"
-            new { Size = new  iTextSharp.text.Rectangle(8f * 28.35f, 30f * 28.35f), Width = 8f, Height = 30f }  // Receipt: 80mm x 300mm (approx)
-        };
-
-            string[] sa = Directory.GetFiles(DirText, "tmpscan*.jpeg");
-
-            List<string> UnSortList = new List<string>(sa);
-            List<string> SortedList = UnSortList.OrderBy(p => PadNumbers(p)).ToList();
-            sa = SortedList.ToArray();
-            string outputPdfPath = Path.Combine(DirText, "tmpscan.pdf");
-
-            using (FileStream fs = new FileStream(outputPdfPath, FileMode.Create, FileAccess.Write, FileShare.None))
-            using (Document doc = new Document(PageSize.A4)) // Default to A4, will resize per page
-            using (PdfWriter writer = PdfWriter.GetInstance(doc, fs))
-            {
-                doc.Open();
-
-                foreach (string imagePath in sa)
-                {
-                    byte[] imageBytes = File.ReadAllBytes(imagePath);
-                    using (MemoryStream ms = new MemoryStream(imageBytes))
-                    using (System.Drawing.Image sysImage = System.Drawing.Image.FromStream(ms))
-                    {
-                        float dpiX = sysImage.HorizontalResolution;
-                        float dpiY = sysImage.VerticalResolution;
-                        float widthInches = sysImage.Width / dpiX;
-                        float heightInches = sysImage.Height / dpiY;
-                        float imageWidthCm = widthInches * 2.54f;
-                        float imageHeightCm = heightInches * 2.54f;
-
-                        bool isLandscape = imageWidthCm > imageHeightCm;
-                        float actualWidth = imageWidthCm;
-                        float actualHeight = imageHeightCm;
-                        if (isLandscape)
-                        {
-                            actualWidth = imageHeightCm;
-                            actualHeight = imageWidthCm;
-                        }
-
-                        // Choose the best predefined paper size
-                        float bestDiff = float.MaxValue;
-                        var bestPaper = predefinedSizes[0];
-
-                        foreach (var paper in predefinedSizes)
-                        {
-                            float paperWidth = paper.Width;
-                            float paperHeight = paper.Height;
-
-                            if (isLandscape && paperWidth < paperHeight)
-                            {
-                                float temp = paperWidth;
-                                paperWidth = paperHeight;
-                                paperHeight = temp;
-                            }
-
-                            float diff = Math.Abs(actualWidth - paperWidth) + Math.Abs(actualHeight - paperHeight);
-                            if (diff < bestDiff)
-                            {
-                                bestDiff = diff;
-                                bestPaper = paper;
-                            }
-                        }
-
-                        // Create a new page for each image
-                        doc.SetPageSize(bestPaper.Size);
-                        doc.NewPage();
-
-                        // Add image to the PDF
-                        iTextSharp.text.Image pdfImage = iTextSharp.text.Image.GetInstance(imageBytes);
-                        pdfImage.ScaleToFit(bestPaper.Size.Width, bestPaper.Size.Height);
-                        pdfImage.SetAbsolutePosition(0, 0);
-                        doc.Add(pdfImage);
-                    }
-                }
-
-                doc.Close();
-            }
-
-        }
-
-
-        
         #endregion
 
         private void SourceListBox_SelectedValueChanged(object sender, EventArgs e)
         {
-            //var t=Task.Run(() =>
-            //{
-            //    LoadScanPropertyValues();
-            //});
-            //t.Wait(1000);
-#if INCLUDE_WIA
-            LoadScanPropertyValues();
-#endif
-
+            // wia
+            this.backend.ChangeSelectedScanner(GetWiaSourceList());
         }
 
+        //private void SourceTwianListBox_SelectedValueChanged(object sender, EventArgs e)
+        //{
+
+        //    //this._twain.SetDefaultSource(sourceTwianListBox.SelectedIndex);
+        //    if (sourceTwianListBox.SelectedIndex >= 0)
+        //    {
+        //        ChangeBackend();
+        //    }
+        //}
         private void SourceTwianListBox_SelectedValueChanged(object sender, EventArgs e)
         {
             //this._twain.SetDefaultSource(sourceTwianListBox.SelectedIndex);
             if (sourceTwianListBox.SelectedIndex >= 0)
             {
-                this._twain.SourceIndex = sourceTwianListBox.SelectedIndex;
+                this.backend.ChangeSelectedScanner(sourceTwianListBox.SelectedIndex);
             }
         }
 
+
         private void MainFrame_FormClosing(object sender, FormClosingEventArgs e)
         {
-            this._twain.CloseDataSource();
-            this._twain.CloseDSM();
+            backend?.Dispose();
         }
 
         private string GetSelectedTwainImageFormat()
         {
-            string format = cmbTwainImageType.SelectedItem.ToString();
+            string format = cmbTwainImageType.SelectedItem.ToString().ToLower();
             return format;
         }
 
@@ -1148,12 +206,117 @@ namespace TownSuite.TwainScanner
         {
             try
             {
-                StartTWIAScanning();
+                backend.Scan(GetSelectedTwainImageFormat());
             }
             catch (Exception ex)
             {
                 MessageBox.Show(ex.Message, I18N.GetString("ScanningError"), MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
+        }
+
+        private IBackend GetBackend(string backend)
+        {
+            switch (backend)
+            {
+                case "originaltwain":
+                    //return new OriginalTwainBackend(dirText, ocr)
+                    //{
+                    //    ParentForm = this
+                    //};
+                    return new Naps2Backend(dirText, ocr)
+                    {
+                        ParentForm = this
+                    };
+#if INCLUDE_WIA
+                case "originalwia":
+                    return new OriginalWiaBackend(dirText, ocr)
+                    {
+                        ParentForm = this
+                    };
+#endif
+                case "naps2":
+                    return new Naps2Backend(dirText, ocr)
+                    {
+                        ParentForm = this
+                    };
+                default:
+                    return new OriginalTwainBackend(dirText, ocr)
+                    {
+                        ParentForm = this
+                    };
+            }
+        }
+
+        private void ChangeBackend()
+        {
+            backend?.Dispose();
+            switch (tabScanDrivers.SelectedTab.Name)
+            {
+                case "tpTWAINScan":
+                    backend = GetBackend("originaltwain");
+                    backend.ConfigureSettings();
+                    cmbTwainImageType.SelectedItem = UserTwainImageType;
+                    sourceTwianListBox.SelectedItem = UserTwainScanner;
+                    break;
+                case "tpWIAScan":
+                    backend = GetBackend("originalwia");
+                    //WIA Settings
+                    backend.ConfigureSettings();
+                    cmbImageType.SelectedIndex = 0;
+                    cmbColor.SelectedIndex = 0;
+
+                    cmbColor.DropDownStyle = ComboBoxStyle.DropDownList;
+                    cmbResolution.DropDownStyle = ComboBoxStyle.DropDownList;
+
+                    break;
+            }
+
+            checkBoxTwainOcr.Visible = ocr.Enabled;
+            checkboxWiaOcr.Visible = ocr.Enabled;
+        }
+
+        #region "helper methods to help refactor the source code"
+        public ToolStripProgressBar GetProgressBar()
+        {
+            return toolStripProgressBar1;
+        }
+
+        public ToolStripStatusLabel GetStatusLabel()
+        {
+            return toolStripStatusLabel1;
+        }
+
+        public ListBox GetWiaSourceList()
+        {
+            return sourceListBox;
+        }
+
+        public ComboBox GetWiaResolution()
+        {
+            return cmbResolution;
+        }
+
+        public ComboBox GetWiaColor()
+        {
+            return cmbColor;
+        }
+
+        public FlowLayoutPanel GetFlowLayoutPanel()
+        {
+            return flowLayoutPanel1;
+        }
+
+        public ListBox GetTwainSourceList()
+        {
+            return sourceTwianListBox;
+        }
+
+
+        #endregion
+
+        private void tabScanDrivers_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            ChangeBackend();
         }
 
     }

--- a/TownSuite.TwainScanner/MainFrame.cs
+++ b/TownSuite.TwainScanner/MainFrame.cs
@@ -22,7 +22,7 @@ namespace TownSuite.TwainScanner
         private string UserTwainImageType;
         private string UserTwainScanner;
         readonly Ocr ocr;
-        IBackend backend;
+        ScannerBackends backend;
         readonly string dirText;
 
 #if INCLUDE_WIA
@@ -214,7 +214,7 @@ namespace TownSuite.TwainScanner
             }
         }
 
-        private IBackend GetBackend(string backend)
+        private ScannerBackends GetBackend(string backend)
         {
             switch (backend)
             {

--- a/TownSuite.TwainScanner/Ocr.cs
+++ b/TownSuite.TwainScanner/Ocr.cs
@@ -16,7 +16,7 @@ namespace TownSuite.TwainScanner
 {
     internal class Ocr
     {
-        public bool Enabled { get; private set; }
+        public bool Enabled { get; set; }
         string _apiUrl;
         string _bearerToken;
 

--- a/TownSuite.TwainScanner/Program.cs
+++ b/TownSuite.TwainScanner/Program.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Windows.Forms;
+using TownSuite.TwainScanner.Backends;
 
 namespace TownSuite.TwainScanner
 {
@@ -18,6 +19,7 @@ namespace TownSuite.TwainScanner
             string ocrApiUrl = "";
             string ocrBearerToken = "";
             string workingDir = Environment.GetEnvironmentVariable("TMP");
+            string backend = "originaltwain";
 
             List<string> scanlist = new List<string>();
             for (int i = 0; i <= Environment.GetCommandLineArgs().Length - 1; i++)
@@ -43,7 +45,7 @@ namespace TownSuite.TwainScanner
                 }
                 if (Environment.GetCommandLineArgs()[i] == "-ocrapiurl")
                 {
-                    ocrApiUrl = Environment.GetCommandLineArgs()[i+1];
+                    ocrApiUrl = Environment.GetCommandLineArgs()[i + 1];
                 }
                 if (Environment.GetCommandLineArgs()[i] == "-ocrbearertoken")
                 {
@@ -53,14 +55,21 @@ namespace TownSuite.TwainScanner
                 {
                     workingDir = Environment.GetCommandLineArgs()[i + 1];
                 }
+                if (Environment.GetCommandLineArgs()[i] == "-backend")
+                {
+                    backend = Environment.GetCommandLineArgs()[i + 1];
+                }
 
             }
+
+            string dirText = Path.Combine(workingDir, "TownSuiteScanner");
 
             if (ScanList == false)
             {
                 Application.EnableVisualStyles();
                 Application.SetCompatibleTextRenderingDefault(false);
-                Application.Run(new MainFrame(settings, new Ocr(enableOcr, ocrApiUrl, ocrBearerToken), workingDir));
+                Application.Run(new MainFrame(settings, new Ocr(enableOcr, ocrApiUrl, ocrBearerToken),
+                    dirText, backend));
             }
             else
             {
@@ -71,9 +80,6 @@ namespace TownSuite.TwainScanner
                 Console.WriteLine("ScanListEnd");
                 Console.Out.Flush();
             }
-
-
-
         }
     }
 }

--- a/TownSuite.TwainScanner/TwainScanner.csproj
+++ b/TownSuite.TwainScanner/TwainScanner.csproj
@@ -3,8 +3,8 @@
 	  <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
 	  <OutputType>WinExe</OutputType>
 	  <RootNamespace>TownSuite.TwainScanner</RootNamespace>
-	  <TargetFrameworks>net48;net8.0-windows</TargetFrameworks>
-	  <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
+	  <TargetFrameworks>net8.0-windows</TargetFrameworks>
+	  <RuntimeIdentifiers>win;win-x86</RuntimeIdentifiers>
 	  <AssemblyName>TownSuite.TwainScanner</AssemblyName>
 	  <AssemblyTitle>TownSuite.TwainScanner</AssemblyTitle>
 	  <Company>TownSuite</Company>
@@ -16,7 +16,7 @@
 	  <PackageVersion>1.0.37</PackageVersion>
 	  <OutputPath>bin\$(Platform)\$(Configuration)\</OutputPath>
 	  <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <Platforms>AnyCPU;x86;x64</Platforms>
+    <Platforms>AnyCPU;x86</Platforms>
 	  <UseWindowsForms>true</UseWindowsForms>
 	  <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
 	
@@ -24,23 +24,16 @@
   <PropertyGroup>
     <AssemblyOriginatorKeyFile />
   </PropertyGroup>
-  <!-- <PropertyGroup Condition=" '$(TargetFramework)' == 'net48'">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net48'">
 	  <DefineConstants>INCLUDE_WIA</DefineConstants>
-  </PropertyGroup> -->
+  </PropertyGroup>
   <PropertyGroup>
     <StartupObject>TownSuite.TwainScanner.Program</StartupObject>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugType>full</DebugType>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <DebugType>full</DebugType>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
-    <DocumentationFile>bin\$(Configuration)\Saraff.Twain.XML</DocumentationFile>
-    <DebugType>pdbonly</DebugType>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <DocumentationFile>bin\$(Configuration)\Saraff.Twain.XML</DocumentationFile>
     <DebugType>pdbonly</DebugType>
   </PropertyGroup>
@@ -115,11 +108,15 @@
   <ItemGroup>
     <EmbeddedResource Include="Resources\scanner.bmp" />
   </ItemGroup>
-  <!-- <ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
+   <ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
 	<PackageReference Include="Wia.Interop.Townsuite.x86" Version="1.0.1" /> 
-  </ItemGroup> -->
+  </ItemGroup> 
 	<ItemGroup>
 		<PackageReference Include="iTextSharp.LGPLv2.Core" Version="3.7.1" />
+		<PackageReference Include="NAPS2.Images.Gdi" Version="1.1.6" />
+		<PackageReference Include="NAPS2.Sdk" Version="1.1.6" />
+		<PackageReference Include="NAPS2.Sdk.Worker.Win32" Version="1.1.6" />
+		<PackageReference Include="System.Linq.Async" Version="6.0.1" />
 	</ItemGroup>
 	
   <ItemGroup Condition=" '$(TargetFramework)' != 'net48' ">

--- a/TownSuite.TwainScanner/TwainScanner.csproj
+++ b/TownSuite.TwainScanner/TwainScanner.csproj
@@ -115,7 +115,9 @@
 		<PackageReference Include="iTextSharp.LGPLv2.Core" Version="3.7.1" />
 		<PackageReference Include="NAPS2.Images.Gdi" Version="1.1.6" />
 		<PackageReference Include="NAPS2.Sdk" Version="1.1.6" />
-		<PackageReference Include="NAPS2.Sdk.Worker.Win32" Version="1.1.6" />
+		<PackageReference Include="NAPS2.Sdk.Worker.Win32" Version="1.1.6">
+			<IncludeAssets>all</IncludeAssets>
+		</PackageReference>
 		<PackageReference Include="System.Linq.Async" Version="6.0.1" />
 	</ItemGroup>
 	


### PR DESCRIPTION
- Updated `Readme.md` with scanner setup instructions.
- Removed x64 configurations from `TownSuite.TwainScanner.sln`.
- Introduced new class structure in `IBackend.cs` for scanning and saving images in multiple formats with OCR support.
- Enhanced `Naps2TwainBackend.cs` and `OriginalTwainBackend.cs` for improved scanning functionality.
- Modified `OriginalWiaBackend.cs` for better WIA scanning management.
- Significant UI updates in `MainFrame.Designer.cs` to accommodate new features.
- Refactored `MainFrame.cs` to support dynamic backend selection (TWAIN, WIA, NAPS2).
- Made `Enabled` property public in `Ocr.cs` for better OCR management.
- Updated `Program.cs` to accept command-line arguments for backend selection.
- Changed `TwainScanner.csproj` to target .NET 8.0 and added necessary package references.