### PR TITLE
Fixed Scan List Function

### DIFF
--- a/TownSuite.TwainScanner/MainFrame.cs
+++ b/TownSuite.TwainScanner/MainFrame.cs
@@ -18,7 +18,7 @@ namespace TownSuite.TwainScanner
 
 
 
-        public MainFrame(List<String> lstScanSet, Ocr ocr, string dirText, string backend)
+        public MainFrame(List<String> lstScanSet, Ocr ocr, string dirText)
         {
             lstscansettings = lstScanSet;
             this.ocr = ocr;
@@ -31,8 +31,6 @@ namespace TownSuite.TwainScanner
         {
             try
             {
-                await LoadBackends();
-                this.backends[0].DeleteFiles();
                 cmbColor.DataSource = Colors.GetColors();
                 cmbColor.DisplayMember = "Name";
                 cmbColor.ValueMember = "Color";
@@ -61,6 +59,10 @@ namespace TownSuite.TwainScanner
                             break;
                     }
                 }
+                await LoadBackends();
+                this.backends[0].DeleteFiles();
+
+
 
             }
             catch (Exception ex)
@@ -168,28 +170,12 @@ namespace TownSuite.TwainScanner
 
         private ScannerBackends CreateBackend(string backend)
         {
-            switch (backend)
+           
+            return new Naps2Backend(dirText, ocr, NewScannerList.GetDriver(backend))
             {
-                case "twain":
-                    //return new OriginalTwainBackend(dirText, ocr)
-                    //{
-                    //    ParentForm = this
-                    //};
-                    return new Naps2Backend(dirText, ocr, NAPS2.Scan.Driver.Twain)
-                    {
-                        ParentForm = this
-                    };
-                case "wia":
-                    return new Naps2Backend(dirText, ocr, NAPS2.Scan.Driver.Wia)
-                    {
-                        ParentForm = this
-                    };
-                default:
-                    return new Naps2Backend(dirText, ocr, NAPS2.Scan.Driver.Twain)
-                    {
-                        ParentForm = this
-                    };
-            }
+                ParentForm = this
+            };
+
         }
 
         private ScannerBackends GetSelectedBackend()
@@ -230,7 +216,23 @@ namespace TownSuite.TwainScanner
             await wiaBackend.ConfigureSettings();
 
             cmbImageType.SelectedItem = UserImageType;
-            sourceListBox.SelectedItem = UserScanner;
+            foreach (ImageFormats imgformat in cmbImageType.Items)
+            {
+                if (string.Equals(imgformat.Name?.Trim(), UserImageType?.Trim(),StringComparison.OrdinalIgnoreCase))
+                {
+                    cmbImageType.SelectedItem = imgformat;
+                    break;
+                }
+            }
+
+            foreach (ScanDevice source in sourceListBox.Items)
+            {
+                if (source.Name?.Trim() == UserScanner?.Trim())
+                {
+                    sourceListBox.SelectedItem = source;
+                    break;
+                }
+            }
 
             ChangeStatus("", false);
 

--- a/TownSuite.TwainScanner/NewScannerList.cs
+++ b/TownSuite.TwainScanner/NewScannerList.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NTwain.Data;
+using NTwain;
+using TownSuite.TwainScanner.Backends;
+using NAPS2.Scan;
+using NAPS2.Images.Gdi;
+
+namespace TownSuite.TwainScanner
+{
+    internal class NewScannerList
+    {
+        public Driver driver;
+        public NewScannerList(Driver driver)
+        {
+            this.driver = driver;
+        
+        }
+
+        public NewScannerList(string driver) : this(GetDriver(driver)) { }
+      
+        public static NAPS2.Scan.Driver GetDriver(string backend)
+        {
+            switch (backend)
+            {
+                case "twain":
+                    //return new OriginalTwainBackend(dirText, ocr)
+                    //{
+                    //    ParentForm = this
+                    //};
+
+                    return NAPS2.Scan.Driver.Twain;
+
+                case "wia":
+                    return NAPS2.Scan.Driver.Wia;
+
+                default:
+                    return NAPS2.Scan.Driver.Twain;
+
+            }
+        }
+        //private Twain32 _twain;
+        public async Task<IEnumerable<string>> ScanList(ScanningContext scanningContext)
+        {
+            List<string> lstscan = new List<string>();
+            try
+            {
+               var list = await GetList(scanningContext);
+                return list.Select(s=>s.Name);
+            }
+            catch (TwainException ex)
+            {
+                if (ex.Message == "It worked!")
+                {
+                    Console.Error.WriteLine("Failed to find a scanner");
+                    Console.Out.Flush();
+                    Console.Error.Flush();
+                }
+                return lstscan;
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine(string.Format("{0}\n\n{1}", ex.Message, ex.StackTrace), "TownSuite Scanner Load Error");
+
+                return lstscan;
+            }
+
+        }
+        public async Task<List<ScanDevice>> GetList(ScanningContext scanningContext)
+        {
+   
+            var controller = GetScanController(scanningContext);
+
+            var scanOptions = new ScanOptions()
+            {
+                Driver = driver
+            };
+            var devices = (await controller.GetDeviceList(scanOptions));
+
+            return devices;
+        }
+
+        public ScanController GetScanController(ScanningContext scanningContext)
+        {
+            if (driver == Driver.Twain)
+            {
+                scanningContext.SetUpWin32Worker();
+            }
+
+            return new ScanController(scanningContext);
+
+        }
+
+      
+        public  ScanningContext GetScanContext()
+        {
+            return new ScanningContext(new GdiImageContext());
+        }
+    }
+
+}


### PR DESCRIPTION
We fixed a bug in TwainScanner that involves using  "-scanlist" parameter. Initially, it was not working so we created a New class Called NewScanList that handles the scanlist functions and shows the list of supported scanner.