### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   windows-build:
     runs-on: windows-latest


### PR DESCRIPTION
Potential fix for [https://github.com/TownSuite/TownSuite.TwainScanner/security/code-scanning/6](https://github.com/TownSuite/TownSuite.TwainScanner/security/code-scanning/6)

In general, to fix this class of problem you add a `permissions` block to the workflow (top level) or to each job, explicitly defining the minimal GITHUB_TOKEN permissions required. For a typical build-and-artifact workflow that only needs to read repository contents, `contents: read` is sufficient.

For this specific `.github/workflows/dotnet.yml`, the `windows-build` job merely checks out code, sets up .NET and MSBuild, builds, runs a script, and uploads artifacts. None of these steps require write access to the repository or other GitHub resources. The cleanest fix is to add a top-level `permissions` block (applies to all jobs) directly under the `on:` section, before `jobs:`, setting `contents: read`. This preserves current behavior while constraining the token to the least privilege required based on the visible steps.

Concretely:
- Edit `.github/workflows/dotnet.yml`.
- After the `on:` block (line 8) and before `jobs:` (line 9), insert:

```yaml
permissions:
  contents: read
```

No new imports or other code changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
